### PR TITLE
Harden admin auth handling and validate upload IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,8 +480,12 @@ export function requireAuth(request: Request, env: { ADMIN_PASSWORD_OWNER: strin
   throw new Response("Unauthorized", { status: 401 });
 }
 
-export function threeDigits(id: string) {
-  return id?.trim().slice(0, 3).padStart(3, "0");
+export function threeDigits(id: string): string | null {
+  if (typeof id !== "string") return null;
+  const trimmed = id.trim();
+  if (!trimmed) return null;
+  if (!/^\d{1,3}$/.test(trimmed)) return null;
+  return trimmed.padStart(3, "0");
 }
 
 export function sanitizeFileName(name: string) {
@@ -505,7 +509,7 @@ export const onRequestPost: PagesFunction = async ({ request, env }) => {
 
     const idRaw = String(form.get("id") ?? "");
     const id = threeDigits(idRaw);
-    if (!id) return errJSON(400, "id is required");
+    if (!id) return errJSON(400, "invalid id");
 
     const file = form.get("file");
     if (!(file instanceof File)) return errJSON(400, "file is required");

--- a/admin.html
+++ b/admin.html
@@ -600,30 +600,10 @@
         // ログイン機能の直接実装（デバッグ用）
         console.log('Admin page loaded');
 
-        // ページロード時に認証状態を確認
+        // ページロード時に旧バージョンの認証ワードを確実に破棄
         window.addEventListener('load', () => {
-            const savedAuth = sessionStorage.getItem('akyoAdminAuth');
-            console.log('Page loaded, auth state:', savedAuth);
-
-            if (savedAuth) {
-                // 既にログイン済みの場合
-                const loginScreen = document.getElementById('loginScreen');
-                const adminScreen = document.getElementById('adminScreen');
-
-                if (loginScreen && adminScreen) {
-                    loginScreen.classList.add('hidden');
-                    adminScreen.classList.remove('hidden');
-                    document.getElementById('logoutBtn').classList.remove('hidden');
-
-                    const roleSpan = document.getElementById('userRole');
-                    if (roleSpan) {
-                        roleSpan.classList.remove('hidden');
-                        roleSpan.textContent = savedAuth === 'owner' ? 'マスター権限' : 'ファインダー権限';
-                        // ログアウトと同一スタイル
-                        roleSpan.className = 'px-3 py-2 rounded-lg bg-gray-700 text-white text-sm';
-                    }
-                }
-            }
+            sessionStorage.removeItem('akyoAdminToken');
+            console.log('Admin fallback loaded');
         });
 
         // handleLogin のフォールバックは無効化（admin.js 実装を使用）
@@ -632,7 +612,6 @@
         if (typeof logout === 'undefined') {
             window.logout = function() {
                 sessionStorage.removeItem('akyoAdminAuth');
-                sessionStorage.removeItem('akyoAdminToken');
                 location.reload();
             }
         }

--- a/functions/_utils.ts
+++ b/functions/_utils.ts
@@ -31,8 +31,12 @@ export function requireAuth(request: Request, env: { ADMIN_PASSWORD_OWNER: strin
   throw new Response("Unauthorized", { status: 401 });
 }
 
-export function threeDigits(id: string) {
-  return id?.trim().slice(0, 3).padStart(3, "0");
+export function threeDigits(id: string): string | null {
+  if (typeof id !== "string") return null;
+  const trimmed = id.trim();
+  if (!trimmed) return null;
+  if (!/^\d{1,3}$/.test(trimmed)) return null;
+  return trimmed.padStart(3, "0");
 }
 
 export function sanitizeFileName(name: string) {

--- a/functions/api/upload.ts
+++ b/functions/api/upload.ts
@@ -11,8 +11,7 @@ export const onRequestPost: PagesFunction = async ({ request, env }) => {
 
     const idRaw = String(form.get("id") ?? "");
     const id = threeDigits(idRaw);
-  if (!id) return errJSON(400, "id is required");
-  if (!/^\d{3}$/.test(id)) return errJSON(400, "invalid id");
+    if (!id) return errJSON(400, "invalid id");
 
     const file = form.get("file");
     if (!(file instanceof File)) return errJSON(400, "file is required");
@@ -41,7 +40,10 @@ export const onRequestPost: PagesFunction = async ({ request, env }) => {
     const data = { id, name, type, desc, key, url, updatedAt: now, updater };
     await (env as any).AKYO_KV.put(`akyo:${id}`, JSON.stringify(data));
 
-    return okJSON({ ok: true, id, url, key, updatedAt: now }, { headers: corsHeaders(request.headers.get("origin") ?? undefined) });
+    return okJSON(
+      { ok: true, id, url, key, updatedAt: now },
+      { headers: corsHeaders(request.headers.get("origin") ?? undefined) }
+    );
   } catch (e: any) {
     if (e instanceof Response) return e;
     return errJSON(500, e?.message || "upload failed");


### PR DESCRIPTION
## Summary
- keep the admin password only in memory, clear legacy storage on load, and guard uploads when the session has expired
- tighten three-digit ID normalization to reject blank or non-numeric values and document the behaviour
- use a chunked ArrayBuffer to Base64 helper to avoid String.fromCharCode spread limits during GitHub uploads

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d436542bdc83239576303bfc701120