### PR TITLE
Ensure icon cache updates complete

### DIFF
--- a/index.html
+++ b/index.html
@@ -441,7 +441,7 @@
     <script>
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {
-                navigator.serviceWorker.register('/sw.js').catch(() => {});
+                navigator.serviceWorker.register('sw.js').catch(() => {});
             });
         }
     </script>

--- a/sw.js
+++ b/sw.js
@@ -1,36 +1,90 @@
-const PRECACHE = 'akyo-precache-v1';
-const PRECACHE_URLS = [
-  '/',
-  '/images/logo.webp',
-  '/images/profileIcon.webp',
-];
+const PRECACHE = 'akyo-precache-v2';
+
+function getPrecacheUrls() {
+  const scope = (self.registration && self.registration.scope) || self.location.href;
+  return [
+    new URL('./', scope).toString(),
+    new URL('./index.html', scope).toString(),
+    new URL('./images/logo.webp', scope).toString(),
+    new URL('./images/profileIcon.webp', scope).toString(),
+  ];
+}
 
 self.addEventListener('install', (event) => {
   event.waitUntil(
-    caches.open(PRECACHE).then((cache) => cache.addAll(PRECACHE_URLS)).then(() => self.skipWaiting())
+    caches
+      .open(PRECACHE)
+      .then((cache) => cache.addAll(getPrecacheUrls()))
+      .then(() => self.skipWaiting())
   );
 });
 
 self.addEventListener('activate', (event) => {
   event.waitUntil(
-    caches.keys().then((keys) => Promise.all(keys.filter((k) => k !== PRECACHE).map((k) => caches.delete(k)))).then(() => self.clients.claim())
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys
+            .filter((key) => key.startsWith('akyo-precache-') && key !== PRECACHE)
+            .map((key) => caches.delete(key))
+        )
+      )
+      .then(() => self.clients.claim())
   );
 });
 
-// Cache-first for icons; network-first fallback
 self.addEventListener('fetch', (event) => {
-  const req = event.request;
-  const url = new URL(req.url);
-  const isIcon = url.pathname.endsWith('/images/logo.webp') || url.pathname.endsWith('/images/profileIcon.webp');
-  if (isIcon) {
-    event.respondWith(
-      caches.match(req).then((cached) => cached || fetch(req).then((res) => {
-        const resClone = res.clone();
-        caches.open(PRECACHE).then((c) => c.put(req, resClone));
-        return res;
-      }))
-    );
+  const { request } = event;
+
+  if (request.method !== 'GET') {
+    return;
   }
+
+  const url = new URL(request.url);
+
+  if (url.origin !== self.location.origin) {
+    return;
+  }
+
+  const scope = (self.registration && self.registration.scope) || self.location.href;
+  const logoPath = new URL('./images/logo.webp', scope).pathname;
+  const profilePath = new URL('./images/profileIcon.webp', scope).pathname;
+  const isIconRequest = url.pathname === logoPath || url.pathname === profilePath;
+
+  if (!isIconRequest) {
+    return;
+  }
+
+  event.respondWith(handleIconRequest(event));
 });
 
+async function handleIconRequest(event) {
+  const { request } = event;
+  const cache = await caches.open(PRECACHE);
+  const cachedResponse = await cache.match(request);
 
+  const networkFetch = (async () => {
+    try {
+      const response = await fetch(request);
+      if (response && response.ok) {
+        await cache.put(request, response.clone());
+      }
+      return response;
+    } catch (error) {
+      return undefined;
+    }
+  })();
+
+  if (cachedResponse) {
+    event.waitUntil(networkFetch);
+    return cachedResponse;
+  }
+
+  const networkResponse = await networkFetch;
+  if (networkResponse) {
+    return networkResponse;
+  }
+
+  return Response.error();
+}


### PR DESCRIPTION
## Summary
- guard the service worker fetch handler to only process same-origin GET icon requests while tolerating missing registration scope
- update icon caching to keep refreshing cached assets via event.waitUntil so background updates complete even when serving cached responses

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d483a1f5748323b44e52253c62d43b