### PR TITLE
Handle cached responses for mini Akyo background

### DIFF
--- a/js/mini-akyo-bg.js
+++ b/js/mini-akyo-bg.js
@@ -17,10 +17,13 @@
 
   async function resolveMiniAkyoUrl(){
     const ver = getVersionSuffix();
+    const ACCEPTABLE = new Set([200, 203, 204, 206, 304]);
     for (const path of CANDIDATES){
       try{
         const r = await fetch(path + ver, { cache: 'no-cache' });
-        if (r.ok) return path + ver;
+        if (r.ok || ACCEPTABLE.has(r.status) || (r.type === 'opaque' && !r.status)) {
+          return path + ver;
+        }
       }catch(_){ /* continue */ }
     }
     return null;


### PR DESCRIPTION
## Summary
- tolerate cached 304/opaque responses when resolving the mini Akyo background image so production can still use the cached asset

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4a1c8a7008323a35948150e068ea5