### PR TITLE
Fix mini Akyo background initialization

### DIFF
--- a/js/mini-akyo-bg.js
+++ b/js/mini-akyo-bg.js
@@ -18,15 +18,20 @@
   async function resolveMiniAkyoUrl(){
     const ver = getVersionSuffix();
     const ACCEPTABLE = new Set([200, 203, 204, 206, 304]);
+    let fallback = null;
+
     for (const path of CANDIDATES){
+      const candidate = path + ver;
+      fallback = fallback || candidate;
       try{
-        const r = await fetch(path + ver, { cache: 'no-cache' });
+        const r = await fetch(candidate, { cache: 'no-cache' });
         if (r.ok || ACCEPTABLE.has(r.status) || (r.type === 'opaque' && !r.status)) {
-          return path + ver;
+          return candidate;
         }
       }catch(_){ /* continue */ }
     }
-    return null;
+
+    return fallback;
   }
 
   function ensureStyles(){
@@ -88,12 +93,20 @@
     host.appendChild(el);
   }
 
-  async function initMiniAkyoBackground(){
+  let initializing = false;
+  let maintainTimer = null;
+  let resizeHandler = null;
+
+  async function initMiniAkyoBackground(force){
+    if (initializing) return;
+    initializing = true;
     try{
       ensureStyles();
       const url = await resolveMiniAkyoUrl();
       if (!url) return;
       const host = createHost();
+
+      if (!force && host.children.length > 0) return;
 
       // 初期クリア（再初期化時の重複防止）
       while (host.firstChild) host.removeChild(host.firstChild);
@@ -106,21 +119,36 @@
       }
 
       const targetDensity = initial;
-      setInterval(() => {
+
+      if (maintainTimer) clearInterval(maintainTimer);
+      maintainTimer = setInterval(() => {
         const current = host.children.length;
         const deficit = targetDensity - current + Math.floor(Math.random()*2); // -1..+?
         const spawnCount = Math.max(0, Math.min(4, deficit));
         for (let i=0;i<spawnCount;i++) spawnOne(host, url);
       }, 2000);
 
-      window.addEventListener('resize', () => {
+      if (resizeHandler) window.removeEventListener('resize', resizeHandler);
+      resizeHandler = () => {
         const ideal = Math.min(22, Math.max(10, Math.round(window.innerWidth/110)));
         while (host.children.length > ideal) host.removeChild(host.firstChild);
-      });
-    }catch(_){ }
+      };
+      window.addEventListener('resize', resizeHandler);
+    }catch(_){
+    }finally{
+      initializing = false;
+    }
   }
 
   if (typeof window !== 'undefined'){
     window.initMiniAkyoBackground = initMiniAkyoBackground;
+    const start = () => {
+      try{ initMiniAkyoBackground(); }catch(_){ }
+    };
+    if (document.readyState === 'loading'){
+      document.addEventListener('DOMContentLoaded', start, { once: true });
+    }else{
+      start();
+    }
   }
 })();


### PR DESCRIPTION
## Summary
- add a graceful fallback so the mini Akyo background still renders when asset prefetch checks fail
- guard the background spawner against duplicate timers and automatically start it once the DOM is ready
- expose a re-runnable initializer that can still be invoked manually when the host container is cleared

## Testing
- (not run)

------
https://chatgpt.com/codex/tasks/task_e_68d4aef6f8ac8323bc486fbe42000e52