### PR TITLE
Add creator filter alongside attribute filter

### DIFF
--- a/index.html
+++ b/index.html
@@ -252,10 +252,13 @@
                     </div>
                 </div>
 
-                <!-- 属性フィルター -->
-                <div>
+                <!-- 属性・作者フィルター -->
+                <div class="space-y-2">
                     <select id="attributeFilter" class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500">
                         <option value="">すべての属性</option>
+                    </select>
+                    <select id="creatorFilter" class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500">
+                        <option value="">すべての作者</option>
                     </select>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- add a new author filter dropdown under the existing attribute filter on the main index page
- populate the author filter from CSV data and hook it into the existing event wiring
- consolidate filter logic so search, attribute, and author filters work together when rendering results

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d4c2800a088323a6b040f5ac0b449e