### PR TITLE
Fix akyo image manifest JSON

### DIFF
--- a/images/manifest.json
+++ b/images/manifest.json
@@ -1,5 +1,4 @@
 {
-<<<<<<< HEAD
   "version": "20250925-171453",
   "map": {
     "100": "https://images.akyodex.com/100.webp",
@@ -615,9 +614,5 @@
     "098": "https://images.akyodex.com/098.webp",
     "099": "https://images.akyodex.com/099.webp"
   },
-=======
-  "version": "20250925-080734",
-  "map": {},
->>>>>>> a94039d13ee124756811ac51de75278b40d81b12
   "miniAkyo": "https://images.akyodex.com/miniakyo.webp"
 }


### PR DESCRIPTION
## Summary
- remove leftover merge-conflict markers from `images/manifest.json`
- restore the full image map entries so Akyo cards can resolve their thumbnails

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4f6dfee008323ab16b4d6919bece0