### PR TITLE
Add ascending/descending sort toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -334,10 +334,13 @@
                     </div>
                     <!-- クイックフィルター（検索ボックス直下に移動） -->
                     <div class="mt-2 flex flex-wrap gap-2 items-center" id="quickFilters">
-                        <button class="attribute-badge quick-filter-badge bg-gray-200 text-gray-700 hover:bg-gray-300 transition-colors">
+                        <button id="sortToggleBtn" class="attribute-badge quick-filter-badge bg-gray-200 text-gray-700 hover:bg-gray-300 transition-colors">
+                            <i class="fas fa-arrow-up-1-9"></i> 昇順
+                        </button>
+                        <button id="randomToggleBtn" class="attribute-badge quick-filter-badge bg-gray-200 text-gray-700 hover:bg-gray-300 transition-colors">
                             <i class="fas fa-dice"></i> ランダム表示
                         </button>
-                        <button class="attribute-badge quick-filter-badge bg-gray-200 text-gray-700 hover:bg-gray-300 transition-colors">
+                        <button id="favoritesToggleBtn" class="attribute-badge quick-filter-badge bg-gray-200 text-gray-700 hover:bg-gray-300 transition-colors">
                             <i class="fas fa-star"></i> お気に入りのみ
                         </button>
                     </div>


### PR DESCRIPTION
## Summary
- add a new quick-filter control to toggle between ascending and descending order
- apply the selected sort order during filtering and update button styling for clear states
- refactor random/favorite quick filters to use explicit IDs and consistent appearance

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d69426329483239005b54cdfc72d54