### PR TITLE
Add secret-mode refresh logic to header logo navigation

### DIFF
--- a/css/kid-friendly.css
+++ b/css/kid-friendly.css
@@ -600,3 +600,32 @@ footer {
 ::-webkit-scrollbar-thumb:hover {
     background: linear-gradient(135deg, var(--primary-blue), var(--primary-pink));
 }
+/* Secret-mode refresh feedback */
+.secret-mode-progress {
+    cursor: progress !important;
+}
+
+.secret-mode-busy {
+    position: relative !important;
+}
+
+.secret-mode-spinner {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 1.75rem;
+    height: 1.75rem;
+    margin-top: -0.875rem;
+    margin-left: -0.875rem;
+    border-radius: 9999px;
+    border: 3px solid rgba(255, 255, 255, 0.65);
+    border-top-color: rgba(249, 115, 22, 0.9);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+    animation: secret-mode-spin 0.75s linear infinite;
+    pointer-events: none;
+}
+
+@keyframes secret-mode-spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}

--- a/index.html
+++ b/index.html
@@ -446,6 +446,114 @@
 
     <!-- ヘッダーロゴ読み込み -->
     <script>
+        const SECRET_MODE_PARAM_KEY = '_akyoFresh';
+        const SECRET_MODE_LOCAL_KEYS = [
+            'akyoDataCSV',
+            'akyoDataVersion',
+            'akyoAssetsVersion',
+            'akyoImages',
+            'akyoHeaderLogo',
+            'akyoHeaderImage',
+            'headerImage',
+            'akyoLogo',
+            'akyoProfileIcon',
+            'akyoCsvLastRefetchAt'
+        ];
+
+        function buildSecretNavigationUrl(homeUrl) {
+            try {
+                const targetUrl = new URL(homeUrl, window.location.href);
+                targetUrl.searchParams.set(SECRET_MODE_PARAM_KEY, Date.now().toString(36));
+                return targetUrl.toString();
+            } catch (_) {
+                return homeUrl;
+            }
+        }
+
+        async function clearTemporarySecretData() {
+            try {
+                SECRET_MODE_LOCAL_KEYS.forEach((key) => {
+                    try {
+                        localStorage.removeItem(key);
+                    } catch (_) {}
+                });
+            } catch (error) {
+                console.warn('ローカルストレージのシークレット消去に失敗:', error);
+            }
+
+            const cleanupTasks = [];
+
+            if (window.storageManager && window.storageManager.isIndexedDBAvailable) {
+                cleanupTasks.push((async () => {
+                    try {
+                        await window.storageManager.init();
+                        await window.storageManager.clearAllImages();
+                    } catch (error) {
+                        console.warn('IndexedDB画像のシークレット消去に失敗:', error);
+                    }
+                })());
+            } else if (window.indexedDB) {
+                cleanupTasks.push(new Promise((resolve) => {
+                    try {
+                        const request = indexedDB.deleteDatabase('AkyoDatabase');
+                        const finish = () => resolve();
+                        request.onsuccess = finish;
+                        request.onerror = finish;
+                        request.onblocked = finish;
+                    } catch (_) {
+                        resolve();
+                    }
+                }));
+            }
+
+            if (window.caches && typeof caches.keys === 'function') {
+                cleanupTasks.push(
+                    caches.keys()
+                        .then((keys) => keys.filter((key) => key.toLowerCase().includes('akyo')))
+                        .then((targetKeys) => Promise.all(targetKeys.map((key) => caches.delete(key).catch(() => false))))
+                        .catch((error) => {
+                            console.warn('キャッシュストレージのシークレット消去に失敗:', error);
+                        })
+                );
+            }
+
+            if (navigator.serviceWorker && navigator.serviceWorker.getRegistrations) {
+                cleanupTasks.push(
+                    navigator.serviceWorker.getRegistrations()
+                        .then((registrations) => Promise.all(registrations.map((reg) => reg.unregister().catch(() => false))))
+                        .catch((error) => {
+                            console.warn('ServiceWorkerのシークレット解除に失敗:', error);
+                        })
+                );
+            }
+
+            await Promise.allSettled(cleanupTasks);
+        }
+
+        function setupSecretModeNavigation(anchor, homeUrl) {
+            if (!anchor || anchor.dataset.secretModeBound === '1') return;
+            anchor.dataset.secretModeBound = '1';
+            anchor.addEventListener('click', async (event) => {
+                try { event.preventDefault(); } catch (_) {}
+
+                anchor.style.pointerEvents = 'none';
+                const navigateTo = buildSecretNavigationUrl(homeUrl);
+
+                const fallbackTimer = setTimeout(() => {
+                    window.location.assign(navigateTo);
+                }, 1500);
+
+                try {
+                    await clearTemporarySecretData();
+                } catch (error) {
+                    console.warn('シークレット効果の適用に失敗:', error);
+                } finally {
+                    clearTimeout(fallbackTimer);
+                    window.location.assign(navigateTo);
+                }
+            });
+        }
+
         // ヘッダーロゴを読み込み
         async function loadHeaderLogo() {
             try {
@@ -506,6 +614,8 @@
                                  style="object-fit: contain; max-width: 420px; cursor: pointer;">
                         </a>
                     `;
+                    const logoLink = headerLogoEl.querySelector('a');
+                    setupSecretModeNavigation(logoLink, homeUrl);
                 } else {
                     // ロゴがない場合でもlogo.pngを直接試し、なければテキスト
                     const currentHost = window.location.hostname;
@@ -525,6 +635,8 @@
                                  alt="Akyoずかん" class="h-full w-auto hover:opacity-90 transition-opacity" style="object-fit: contain; max-width: 420px; cursor: pointer;">
                         </a>
                     `;
+                    const logoLink = headerLogoEl.querySelector('a');
+                    setupSecretModeNavigation(logoLink, homeUrl);
                 }
 
             } catch (error) {

--- a/index.html
+++ b/index.html
@@ -443,132 +443,16 @@
     <script src="js/image-loader.js"></script>
     <script src="js/main.js"></script>
     <script src="js/mini-akyo-bg.js?v=2"></script>
+    <script src="js/secret-mode.js"></script>
 
     <!-- ヘッダーロゴ読み込み -->
     <script>
-        const SECRET_MODE_PARAM_KEY = '_akyoFresh';
-        const SECRET_MODE_LOCAL_KEYS = [
-            'akyoDataCSV',
-            'akyoDataVersion',
-            'akyoAssetsVersion',
-            'akyoImages',
-            'akyoHeaderLogo',
-            'akyoHeaderImage',
-            'headerImage',
-            'akyoLogo',
-            'akyoProfileIcon',
-            'akyoCsvLastRefetchAt'
-        ];
-
-        function buildSecretNavigationUrl(homeUrl) {
-            try {
-                const targetUrl = new URL(homeUrl, window.location.href);
-                targetUrl.searchParams.set(SECRET_MODE_PARAM_KEY, Date.now().toString(36));
-                return targetUrl.toString();
-            } catch (_) {
-                return homeUrl;
-            }
-        }
-
-        async function clearTemporarySecretData() {
-            try {
-                SECRET_MODE_LOCAL_KEYS.forEach((key) => {
-                    try {
-                        localStorage.removeItem(key);
-                    } catch (_) {}
-                });
-            } catch (error) {
-                console.warn('ローカルストレージのシークレット消去に失敗:', error);
-            }
-
-            try {
-                sessionStorage.clear();
-            } catch (error) {
-                console.warn('セッションストレージのシークレット消去に失敗:', error);
-            }
-
-            const cleanupTasks = [];
-
-            if (window.storageManager && window.storageManager.isIndexedDBAvailable) {
-                cleanupTasks.push((async () => {
-                    try {
-                        await window.storageManager.init();
-                        await window.storageManager.clearAllImages();
-                    } catch (error) {
-                        console.warn('IndexedDB画像のシークレット消去に失敗:', error);
-                    }
-                })());
-            } else if (window.indexedDB) {
-                cleanupTasks.push(new Promise((resolve) => {
-                    try {
-                        const request = indexedDB.deleteDatabase('AkyoDatabase');
-                        const finish = () => resolve();
-                        request.onsuccess = finish;
-                        request.onerror = finish;
-                        request.onblocked = finish;
-                    } catch (_) {
-                        resolve();
-                    }
-                }));
-            }
-
-            if (window.caches && typeof caches.keys === 'function') {
-                cleanupTasks.push(
-                    caches.keys()
-                        .then((keys) => keys.filter((key) => key.toLowerCase().includes('akyo')))
-                        .then((targetKeys) => Promise.all(targetKeys.map((key) => caches.delete(key).catch(() => false))))
-                        .catch((error) => {
-                            console.warn('キャッシュストレージのシークレット消去に失敗:', error);
-                        })
-                );
-            }
-
-            if (navigator.serviceWorker && navigator.serviceWorker.getRegistrations) {
-                cleanupTasks.push(
-                    navigator.serviceWorker.getRegistrations()
-                        .then((registrations) => Promise.all(registrations.map((reg) => reg.unregister().catch(() => false))))
-                        .catch((error) => {
-                            console.warn('ServiceWorkerのシークレット解除に失敗:', error);
-                        })
-                );
-            }
-
-            await Promise.allSettled(cleanupTasks);
-        }
-
-        function setupSecretModeNavigation(anchor, homeUrl) {
-            if (!anchor || anchor.dataset.secretModeBound === '1') return;
-            anchor.dataset.secretModeBound = '1';
-            anchor.addEventListener('click', async (event) => {
-                if (
-                    event.defaultPrevented ||
-                    event.metaKey ||
-                    event.ctrlKey ||
-                    event.shiftKey ||
-                    event.button === 1
-                ) {
-                    return;
-                }
-
-                try { event.preventDefault(); } catch (_) {}
-
-                anchor.setAttribute('aria-disabled', 'true');
-                anchor.style.pointerEvents = 'none';
-                const navigateTo = buildSecretNavigationUrl(homeUrl);
-
-                const fallbackTimer = setTimeout(() => {
-                    window.location.replace(navigateTo);
-                }, 1500);
-
-                try {
-                    await clearTemporarySecretData();
-                } catch (error) {
-                    console.warn('シークレット効果の適用に失敗:', error);
-                } finally {
-                    clearTimeout(fallbackTimer);
-                    window.location.replace(navigateTo);
-                }
-            }, { once: true });
+        const secretMode = window.secretMode;
+        const setupSecretModeNavigation = typeof secretMode?.setupSecretModeNavigation === 'function'
+            ? secretMode.setupSecretModeNavigation
+            : null;
+        if (!setupSecretModeNavigation) {
+            console.warn('Secret mode utilities were not initialised correctly.');
         }
 
         // ヘッダーロゴを読み込み
@@ -632,7 +516,9 @@
                         </a>
                     `;
                     const logoLink = headerLogoEl.querySelector('a');
-                    setupSecretModeNavigation(logoLink, homeUrl);
+                    if (setupSecretModeNavigation && logoLink) {
+                        setupSecretModeNavigation(logoLink, homeUrl);
+                    }
                 } else {
                     // ロゴがない場合でもlogo.pngを直接試し、なければテキスト
                     const currentHost = window.location.hostname;
@@ -653,7 +539,9 @@
                         </a>
                     `;
                     const logoLink = headerLogoEl.querySelector('a');
-                    setupSecretModeNavigation(logoLink, homeUrl);
+                    if (setupSecretModeNavigation && logoLink) {
+                        setupSecretModeNavigation(logoLink, homeUrl);
+                    }
                 }
 
             } catch (error) {

--- a/index.html
+++ b/index.html
@@ -481,6 +481,12 @@
                 console.warn('ローカルストレージのシークレット消去に失敗:', error);
             }
 
+            try {
+                sessionStorage.clear();
+            } catch (error) {
+                console.warn('セッションストレージのシークレット消去に失敗:', error);
+            }
+
             const cleanupTasks = [];
 
             if (window.storageManager && window.storageManager.isIndexedDBAvailable) {
@@ -534,13 +540,24 @@
             if (!anchor || anchor.dataset.secretModeBound === '1') return;
             anchor.dataset.secretModeBound = '1';
             anchor.addEventListener('click', async (event) => {
+                if (
+                    event.defaultPrevented ||
+                    event.metaKey ||
+                    event.ctrlKey ||
+                    event.shiftKey ||
+                    event.button === 1
+                ) {
+                    return;
+                }
+
                 try { event.preventDefault(); } catch (_) {}
 
+                anchor.setAttribute('aria-disabled', 'true');
                 anchor.style.pointerEvents = 'none';
                 const navigateTo = buildSecretNavigationUrl(homeUrl);
 
                 const fallbackTimer = setTimeout(() => {
-                    window.location.assign(navigateTo);
+                    window.location.replace(navigateTo);
                 }, 1500);
 
                 try {
@@ -549,9 +566,9 @@
                     console.warn('シークレット効果の適用に失敗:', error);
                 } finally {
                     clearTimeout(fallbackTimer);
-                    window.location.assign(navigateTo);
+                    window.location.replace(navigateTo);
                 }
-            });
+            }, { once: true });
         }
 
         // ヘッダーロゴを読み込み

--- a/js/secret-mode.js
+++ b/js/secret-mode.js
@@ -1,0 +1,215 @@
+'use strict';
+
+(function attachSecretModeUtilities(global) {
+    if (!global || global.secretMode) return;
+
+    const SECRET_MODE_PARAM_KEY = '_akyoFresh';
+    const SECRET_MODE_LOCAL_KEYS = Object.freeze([
+        'akyoDataCSV',
+        'akyoDataVersion',
+        'akyoAssetsVersion',
+        'akyoImages',
+        'akyoHeaderLogo',
+        'akyoHeaderImage',
+        'headerImage',
+        'akyoLogo',
+        'akyoProfileIcon',
+        'akyoCsvLastRefetchAt'
+    ]);
+    const SECRET_MODE_CACHE_KEY_FILTER = 'akyo';
+    const SECRET_MODE_SERVICE_WORKER_SCOPE_PREFIX = '/';
+    const BODY_PROGRESS_CLASS = 'secret-mode-progress';
+    const BUSY_ANCHOR_CLASS = 'secret-mode-busy';
+    const SPINNER_CLASS = 'secret-mode-spinner';
+
+    function buildSecretNavigationUrl(homeUrl) {
+        try {
+            const targetUrl = new URL(homeUrl, global.location.href);
+            targetUrl.searchParams.set(SECRET_MODE_PARAM_KEY, Date.now().toString(36));
+            return targetUrl.toString();
+        } catch (_) {
+            return homeUrl;
+        }
+    }
+
+    function removeLocalStorageKeys() {
+        SECRET_MODE_LOCAL_KEYS.forEach((key) => {
+            try {
+                global.localStorage.removeItem(key);
+            } catch (_) {}
+        });
+    }
+
+    function applyPendingVisualState(anchor) {
+        let cleanup = () => {};
+        if (!anchor) {
+            if (global.document?.body) {
+                global.document.body.classList.add(BODY_PROGRESS_CLASS);
+                cleanup = () => global.document.body.classList.remove(BODY_PROGRESS_CLASS);
+            }
+            return cleanup;
+        }
+
+        const doc = anchor.ownerDocument || global.document;
+        if (!doc) return cleanup;
+
+        const body = doc.body;
+        if (body) {
+            body.classList.add(BODY_PROGRESS_CLASS);
+        }
+
+        const spinner = doc.createElement('span');
+        spinner.className = SPINNER_CLASS;
+        spinner.setAttribute('aria-hidden', 'true');
+
+        anchor.classList.add(BUSY_ANCHOR_CLASS);
+        anchor.appendChild(spinner);
+
+        cleanup = () => {
+            if (spinner.parentElement === anchor) {
+                spinner.remove();
+            }
+            anchor.classList.remove(BUSY_ANCHOR_CLASS);
+            if (body) {
+                body.classList.remove(BODY_PROGRESS_CLASS);
+            }
+        };
+
+        return cleanup;
+    }
+
+    async function clearTemporarySecretData() {
+        try {
+            removeLocalStorageKeys();
+        } catch (error) {
+            console.warn('ローカルストレージのシークレット消去に失敗:', error);
+        }
+
+        try {
+            global.sessionStorage.clear();
+        } catch (error) {
+            console.warn('セッションストレージのシークレット消去に失敗:', error);
+        }
+
+        const cleanupTasks = [];
+
+        if (global.window?.storageManager && global.window.storageManager.isIndexedDBAvailable) {
+            cleanupTasks.push((async () => {
+                try {
+                    await global.window.storageManager.init();
+                    await global.window.storageManager.clearAllImages();
+                } catch (error) {
+                    console.warn('IndexedDB画像のシークレット消去に失敗:', error);
+                }
+            })());
+        } else if (global.indexedDB) {
+            cleanupTasks.push(new Promise((resolve) => {
+                try {
+                    const request = global.indexedDB.deleteDatabase('AkyoDatabase');
+                    const finish = () => resolve();
+                    request.onsuccess = finish;
+                    request.onerror = finish;
+                    request.onblocked = finish;
+                } catch (_) {
+                    resolve();
+                }
+            }));
+        }
+
+        if (global.caches && typeof global.caches.keys === 'function') {
+            const filterNeedle = SECRET_MODE_CACHE_KEY_FILTER.toLowerCase();
+            cleanupTasks.push(
+                global.caches.keys()
+                    .then((keys) => {
+                        if (!filterNeedle) return keys;
+                        return keys.filter((key) => key.toLowerCase().startsWith(filterNeedle));
+                    })
+                    .then((targetKeys) => Promise.all(targetKeys.map((key) => global.caches.delete(key).catch(() => false))))
+                    .catch((error) => {
+                        console.warn('キャッシュストレージのシークレット消去に失敗:', error);
+                    })
+            );
+        }
+
+        if (global.navigator?.serviceWorker && global.navigator.serviceWorker.getRegistrations) {
+            cleanupTasks.push(
+                global.navigator.serviceWorker.getRegistrations()
+                    .then((registrations) => {
+                        const scopePrefix = new URL(SECRET_MODE_SERVICE_WORKER_SCOPE_PREFIX, global.location.origin).href;
+                        return Promise.all(
+                            registrations
+                                .filter((reg) => {
+                                    try {
+                                        return reg.scope.startsWith(scopePrefix);
+                                    } catch (_) {
+                                        return true;
+                                    }
+                                })
+                                .map((reg) => reg.unregister().catch(() => false))
+                        );
+                    })
+                    .catch((error) => {
+                        console.warn('ServiceWorkerのシークレット解除に失敗:', error);
+                    })
+            );
+        }
+
+        await Promise.allSettled(cleanupTasks);
+    }
+
+    function setupSecretModeNavigation(anchor, homeUrl) {
+        if (!anchor || anchor.dataset.secretModeBound === '1') return;
+        anchor.dataset.secretModeBound = '1';
+
+        anchor.addEventListener('click', async (event) => {
+            if (
+                event.defaultPrevented ||
+                event.metaKey ||
+                event.ctrlKey ||
+                event.shiftKey ||
+                event.button === 1
+            ) {
+                return;
+            }
+
+            try { event.preventDefault(); } catch (_) {}
+
+            anchor.setAttribute('aria-disabled', 'true');
+            anchor.style.pointerEvents = 'none';
+
+            const cleanupVisualState = applyPendingVisualState(anchor);
+            const navigateTo = buildSecretNavigationUrl(homeUrl);
+
+            const fallbackTimer = global.setTimeout(() => {
+                cleanupVisualState();
+                global.location.replace(navigateTo);
+            }, 1500);
+
+            try {
+                await clearTemporarySecretData();
+            } catch (error) {
+                console.warn('シークレット効果の適用に失敗:', error);
+            } finally {
+                global.clearTimeout(fallbackTimer);
+                cleanupVisualState();
+                global.location.replace(navigateTo);
+            }
+        }, { once: true });
+    }
+
+    const api = Object.freeze({
+        SECRET_MODE_PARAM_KEY,
+        SECRET_MODE_LOCAL_KEYS,
+        SECRET_MODE_CACHE_KEY_FILTER,
+        SECRET_MODE_SERVICE_WORKER_SCOPE_PREFIX,
+        buildSecretNavigationUrl,
+        clearTemporarySecretData,
+        setupSecretModeNavigation
+    });
+
+    Object.defineProperty(global, 'secretMode', {
+        value: api,
+        writable: false,
+        configurable: false
+    });
+})(typeof window !== 'undefined' ? window : this);


### PR DESCRIPTION
## Summary
- add helper utilities in index.html to clear cached data and unregister service workers when the header logo is clicked
- append a cache-busting parameter and disable pointer events to mimic a temporary secret-browser refresh before navigating home
- wire the new behavior into both dynamic and fallback logo link render paths

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d72b23fb888323b8f15175e9f6fc6e