### PR TITLE
Fix search input padding to avoid overlapping icon

### DIFF
--- a/css/kid-friendly.css
+++ b/css/kid-friendly.css
@@ -231,7 +231,7 @@ button, .btn {
     border-radius: 25px !important;
     border: 3px solid var(--primary-blue) !important;
     font-size: 18px !important;
-    padding: 12px 20px !important;
+    padding: 12px 20px 12px 52px !important;
     background: white !important;
     transition: all 0.3s ease !important;
 }


### PR DESCRIPTION
## Summary
- increase the left padding on the Akyo search input so typing no longer collides with the magnifier icon

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d74075a7d08323b8e33cd38eac14ec