### PR TITLE
Add cache-busting version for kid-friendly stylesheet

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -21,7 +21,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Kosugi+Maru&family=M+PLUS+Rounded+1c:wght@400;700;900&family=Noto+Sans+JP:wght@300;400;500;700;900&display=swap" rel="stylesheet">
 
     <!-- 子どもにやさしいデザイン -->
-    <link rel="stylesheet" href="css/kid-friendly.css">
+    <link rel="stylesheet" href="css/kid-friendly.css?v=20250927">
 
     <!-- ストレージファインダー -->
     <script src="js/storage-manager.js"></script>

--- a/finder.html
+++ b/finder.html
@@ -20,7 +20,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Kosugi+Maru&family=M+PLUS+Rounded+1c:wght@400;700;900&family=Noto+Sans+JP:wght@300;400;500;700;900&display=swap" rel="stylesheet">
 
     <!-- 子どもにやさしいデザイン -->
-    <link rel="stylesheet" href="css/kid-friendly.css">
+    <link rel="stylesheet" href="css/kid-friendly.css?v=20250927">
 
     <!-- ストレージファインダー -->
     <script src="js/storage-manager.js"></script>

--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Kosugi+Maru&family=M+PLUS+Rounded+1c:wght@400;700;900&family=Noto+Sans+JP:wght@300;400;500;700;900&display=swap" rel="stylesheet">
 
     <!-- 子どもにやさしいデザイン -->
-    <link rel="stylesheet" href="css/kid-friendly.css">
+    <link rel="stylesheet" href="css/kid-friendly.css?v=20250927">
 
     <script type="application/ld+json">
     {

--- a/logo-upload.html
+++ b/logo-upload.html
@@ -13,7 +13,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Kosugi+Maru&family=M+PLUS+Rounded+1c:wght@400;700;900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="css/kid-friendly.css">
+    <link rel="stylesheet" href="css/kid-friendly.css?v=20250927">
     <style>
         .crop-container {
             position: relative;

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,5 @@
-const PRECACHE = 'akyo-precache-v6';
+const PRECACHE = 'akyo-precache-v7';
+const CSS_VERSION = '20250927';
 let precacheUrlList = null;
 let precacheUrlSet = null;
 
@@ -8,12 +9,19 @@ function getScope() {
 
 function buildPrecacheUrls() {
   const scope = getScope();
+  const cssAssets = CSS_VERSION
+    ? [
+        './css/kid-friendly.css',
+        `./css/kid-friendly.css?v=${CSS_VERSION}`,
+      ]
+    : ['./css/kid-friendly.css'];
+
   const coreAssets = [
     './',
     './index.html',
     './admin.html',
     './logo-upload.html',
-    './css/kid-friendly.css',
+    ...cssAssets,
     './js/storage-manager.js',
     './js/storage-adapter.js',
     './js/image-manifest-loader.js',


### PR DESCRIPTION
## Summary
- append a version query string to kid-friendly.css so browsers and CDN edge nodes fetch the updated background rules
- bump the service worker precache version and include both old and new stylesheet URLs to keep offline support

## Testing
- not run (static asset change)


------
https://chatgpt.com/codex/tasks/task_e_68d741ae4a148323ac446cdea36ebe5b