### PR TITLE
Fix search box icon overlapping typed text

### DIFF
--- a/css/kid-friendly.css
+++ b/css/kid-friendly.css
@@ -231,7 +231,7 @@ button, .btn {
     border-radius: 25px !important;
     border: 3px solid var(--primary-blue) !important;
     font-size: 18px !important;
-    padding: 12px 20px 12px 52px !important;
+    padding: 12px 20px 12px 60px !important;
     background: white !important;
     transition: all 0.3s ease !important;
 }

--- a/index.html
+++ b/index.html
@@ -327,10 +327,12 @@
                         <input
                             type="text"
                             id="searchInput"
-                            placeholder="  Akyoを検索... (名前、ID、属性など)"
-                            class="w-full px-4 py-3 pl-12 pr-4 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500"
+                            placeholder="Akyoを検索... (名前、ID、属性など)"
+                            class="w-full px-4 py-3 pl-14 pr-4 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500"
                         >
-                        <i class="fas fa-search absolute left-4 top-4 text-gray-400"></i>
+                        <span class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-4 text-gray-400">
+                            <i class="fas fa-search" aria-hidden="true"></i>
+                        </span>
                     </div>
                     <!-- クイックフィルター（検索ボックス直下に移動） -->
                     <div class="mt-2 flex flex-wrap gap-2 items-center" id="quickFilters">


### PR DESCRIPTION
## Summary
- update the search field markup to provide a dedicated container for the magnifying glass icon and extra left padding
- align the kid-friendly stylesheet padding with the new markup so typed text no longer overlaps the icon

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68d74420144c83239cdca1df96bc0f11