### PR TITLE
Close Akyo detail modal on outside click

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -706,7 +706,12 @@ function setupEventListeners() {
     const detailModal = document.getElementById('detailModal');
     if (detailModal) {
         detailModal.addEventListener('click', (e) => {
-            if (e.target.id === 'detailModal') closeModal();
+            const modalContentContainer = detailModal.querySelector('.bg-white');
+            if (!modalContentContainer) return;
+            const clickedOutside = !modalContentContainer.contains(e.target);
+            if (clickedOutside) {
+                closeModal();
+            }
         });
     }
 }


### PR DESCRIPTION
## Summary
- close the Akyo detail modal when clicking anywhere outside the modal content

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d7526327288323b6dc6fea9125fc44