### PR TITLE
Streamline Akyo image editing uploads

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -256,7 +256,7 @@
                             画像を公開用にアップロード
                         </button>
                     </div>
-                    <p class="text-xs text-gray-500 mt-1">保存に成功すると、図鑑でもすぐ表示されます（対応形式: WebP / PNG / JPG）。</p>
+                    <p class="text-xs text-gray-500 mt-1">保存に成功すると、図鑑でもすぐ表示されます（アップロード時に自動でWebPへ変換されます。入力形式: WebP / PNG / JPG）。</p>
                 </div>
 
                 <button type="submit" class="w-full bg-gradient-to-r from-green-500 to-blue-500 text-white py-3 rounded-lg font-medium hover:opacity-90 transition-opacity">
@@ -604,12 +604,16 @@
 
                     // 結果を返す
                     canvas.toBlob((blob) => {
+                        if (!blob) {
+                            resolve(null);
+                            return;
+                        }
                         const reader = new FileReader();
                         reader.onloadend = () => {
                             resolve(reader.result);
                         };
                         reader.readAsDataURL(blob);
-                    }, 'image/jpeg', 0.9);
+                    }, 'image/webp', 0.92);
                 };
                 image.src = originalImageSrc || img.src;
             });

--- a/functions/api/upload.ts
+++ b/functions/api/upload.ts
@@ -8,8 +8,8 @@ import {
   threeDigits,
 } from "../_utils";
 
-const ALLOWED_MIME_TYPES = new Set(["image/webp", "image/png", "image/jpeg"]);
-const ALLOWED_EXTENSIONS = new Set([".webp", ".png", ".jpg", ".jpeg"]);
+const ALLOWED_MIME_TYPES = new Set(["image/webp"]);
+const ALLOWED_EXTENSIONS = new Set([".webp"]);
 const DEFAULT_MAX_SIZE = 10 * 1024 * 1024; // 10MB
 
 // Cloudflare Pages Functions 用の型定義（TypeScript エラーを解消）
@@ -58,7 +58,7 @@ export const onRequestPost: PagesFunction = async ({ request, env }) => {
       return errJSON(413, "file too large");
     }
 
-    const key = `images/${id}_${safeName}`; // 実ファイル名は自由だが先頭3桁IDで揃える
+    const key = `${id}.webp`;
 
     await (env as any).AKYO_BUCKET.put(key, file.stream(), {
       httpMetadata: {
@@ -67,8 +67,9 @@ export const onRequestPost: PagesFunction = async ({ request, env }) => {
       },
     });
 
-    const base = (env as any).PUBLIC_R2_BASE as string; // 例: https://images.akyodex.com
-    const url = `${base}/${key}`;
+    const baseRaw = (env as any).PUBLIC_R2_BASE as string | undefined;
+    const base = typeof baseRaw === "string" ? baseRaw.replace(/\/+$/, "") : "";
+    const url = base ? `${base}/${key}` : key;
 
     // メタデータ（最小）
     const name = String(form.get("name") ?? "");


### PR DESCRIPTION
## Summary
- update the admin editing flow to publish selected images to the CDN while keeping local fallbacks in sync
- extend the upload helper so edits can reuse prepared data URLs and ensure the request always contains an `<id>.webp` file
- store new uploads at the CDN root and write manifest entries with full URLs for both R2 and GitHub paths

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d74aa12a70832391982188dc722d7d