### PR TITLE
Fix Akyo detail modal closing on outside interaction

### DIFF
--- a/index.html
+++ b/index.html
@@ -411,7 +411,7 @@
         <div class="modal-backdrop fixed inset-0" onclick="closeModal()"></div>
         <div class="relative min-h-screen px-4 py-8">
             <div class="relative mx-auto max-w-2xl">
-                <div class="bg-white rounded-3xl shadow-2xl">
+                <div class="bg-white rounded-3xl shadow-2xl" data-modal-content>
                     <!-- クローズボタン -->
                     <button id="closeModal" onclick="closeModal()"
                             class="absolute top-4 right-4 w-14 h-14 rounded-full z-[60] flex items-center justify-center transition-all duration-300"

--- a/js/main.js
+++ b/js/main.js
@@ -704,10 +704,43 @@ function setupEventListeners() {
     }
 
     const detailModal = document.getElementById('detailModal');
-    if (detailModal) {
-        detailModal.addEventListener('click', (e) => {
-            if (e.target.id === 'detailModal') closeModal();
+    if (detailModal && !detailModal.dataset.outsideCloseInitialized) {
+        const isEventInsideModal = (event) => {
+            const modalContentContainer = detailModal.querySelector('[data-modal-content]');
+            return modalContentContainer ? modalContentContainer.contains(event.target) : false;
+        };
+
+        const handlePointerDownOutsideModal = (event) => {
+            if (detailModal.classList.contains('hidden')) return;
+            if (!isEventInsideModal(event)) {
+                closeModal();
+            }
+        };
+
+        const handleClickOutsideModal = (event) => {
+            if (detailModal.classList.contains('hidden')) return;
+            if (!isEventInsideModal(event)) {
+                closeModal();
+            }
+        };
+
+        const outsideCloseEvents = window.PointerEvent
+            ? ['pointerdown']
+            : ['mousedown', 'touchstart'];
+
+        outsideCloseEvents.forEach((eventName) => {
+            document.addEventListener(eventName, handlePointerDownOutsideModal, true);
         });
+
+        detailModal.addEventListener('click', handleClickOutsideModal);
+
+        document.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape' && !detailModal.classList.contains('hidden')) {
+                closeModal();
+            }
+        });
+
+        detailModal.dataset.outsideCloseInitialized = 'true';
     }
 }
 
@@ -1469,7 +1502,9 @@ async function showDetail(akyoId) {
 
 // モーダルを閉じる
 function closeModal() {
-    document.getElementById('detailModal').classList.add('hidden');
+    const modal = document.getElementById('detailModal');
+    if (!modal) return;
+    modal.classList.add('hidden');
 }
 
 // お気に入り切り替え


### PR DESCRIPTION
## Summary
- reuse a helper to detect whether an event target is inside the Akyo detail panel
- close the modal when clicks land outside the content area in addition to pointer-based detection

## Testing
- not run (manual verification)


------
https://chatgpt.com/codex/tasks/task_e_68d7526327288323b6dc6fea9125fc44