### PR TITLE
Add cache-busting version suffix to uploaded image keys

### DIFF
--- a/functions/api/upload.ts
+++ b/functions/api/upload.ts
@@ -58,7 +58,8 @@ export const onRequestPost: PagesFunction = async ({ request, env }) => {
       return errJSON(413, "file too large");
     }
 
-    const key = `images/${id}_${safeName}`; // 実ファイル名は自由だが先頭3桁IDで揃える
+    const version = Date.now().toString(36);
+    const key = `images/${id}_${version}_${safeName}`; // 実ファイル名は自由だが先頭3桁IDで揃える
 
     await (env as any).AKYO_BUCKET.put(key, file.stream(), {
       httpMetadata: {
@@ -77,7 +78,7 @@ export const onRequestPost: PagesFunction = async ({ request, env }) => {
     const now = new Date().toISOString();
     const updater = role; // ロールのみ記録（必要ならIP/UAも）
 
-    const data = { id, name, type, desc, key, url, updatedAt: now, updater };
+    const data = { id, name, type, desc, key, url, updatedAt: now, updater, version };
     await (env as any).AKYO_KV.put(`akyo:${id}`, JSON.stringify(data));
 
     return okJSON(


### PR DESCRIPTION
## Summary
- add a timestamp-based suffix when storing uploaded Akyo images so new uploads generate unique URLs
- persist the generated upload version in KV metadata for potential downstream use

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d75cb18b288323bc478b4dc8255395