### PR TITLE
Add data URL fallback for Akyo image updates

### DIFF
--- a/functions/api/upload.ts
+++ b/functions/api/upload.ts
@@ -8,7 +8,7 @@ import {
   threeDigits,
 } from "../_utils";
 
-const ALLOWED_MIME_TYPES = new Set(["image/webp", "image/png", "image/jpeg"]);
+const ALLOWED_MIME_TYPES = new Set(["image/webp", "image/png", "image/jpeg", "image/jpg"]);
 const ALLOWED_EXTENSIONS = new Set([".webp", ".png", ".jpg", ".jpeg"]);
 const DEFAULT_MAX_SIZE = 10 * 1024 * 1024; // 10MB
 
@@ -38,29 +38,22 @@ export const onRequestPost: PagesFunction = async ({ request, env }) => {
     if (!id) return errJSON(400, "invalid id");
 
     const file = form.get("file");
-    if (!(file instanceof File)) return errJSON(400, "file is required");
+    const dataUrl = form.get("dataUrl");
 
-    const original = file.name || `${id}.webp`;
-    const safeName = sanitizeFileName(original);
-    const extIndex = safeName.lastIndexOf(".");
-    const ext = extIndex >= 0 ? safeName.slice(extIndex) : "";
-    if (!ALLOWED_EXTENSIONS.has(ext)) {
-      return errJSON(415, "unsupported file extension");
-    }
+    const parsed = normalizeUploadPayload(id, file, dataUrl);
+    if (parsed.error) return parsed.error;
 
-    const mime = (file as any).type ? String((file as any).type).toLowerCase() : "";
-    if (mime && !ALLOWED_MIME_TYPES.has(mime)) {
-      return errJSON(415, "unsupported mime type");
-    }
+    const { safeName, mime, body, size } = parsed;
 
     const maxSize = Number((env as any).MAX_UPLOAD_SIZE_BYTES ?? DEFAULT_MAX_SIZE);
-    if (Number.isFinite(maxSize) && file.size > maxSize) {
+    if (Number.isFinite(maxSize) && size > maxSize) {
       return errJSON(413, "file too large");
     }
 
-    const key = `images/${id}_${safeName}`; // 実ファイル名は自由だが先頭3桁IDで揃える
+    const version = Date.now().toString(36);
+    const key = `images/${id}_${version}_${safeName}`; // 実ファイル名は自由だが先頭3桁IDで揃える
 
-    await (env as any).AKYO_BUCKET.put(key, file.stream(), {
+    await (env as any).AKYO_BUCKET.put(key, body, {
       httpMetadata: {
         contentType: mime || "application/octet-stream",
         cacheControl: "public, max-age=31536000, immutable",
@@ -77,7 +70,7 @@ export const onRequestPost: PagesFunction = async ({ request, env }) => {
     const now = new Date().toISOString();
     const updater = role; // ロールのみ記録（必要ならIP/UAも）
 
-    const data = { id, name, type, desc, key, url, updatedAt: now, updater };
+    const data = { id, name, type, desc, key, url, updatedAt: now, updater, version };
     await (env as any).AKYO_KV.put(`akyo:${id}`, JSON.stringify(data));
 
     return okJSON(
@@ -89,3 +82,98 @@ export const onRequestPost: PagesFunction = async ({ request, env }) => {
     return errJSON(500, e?.message || "upload failed");
   }
 };
+
+function normalizeUploadPayload(
+  id: string,
+  file: FormDataEntryValue | null,
+  dataUrl: FormDataEntryValue | null
+):
+  | {
+      safeName: string;
+      mime: string;
+      body: ReadableStream | ArrayBuffer | Uint8Array;
+      size: number;
+      error?: undefined;
+    }
+  | { error: Response } {
+  if (file instanceof File && file.size > 0) {
+    const original = file.name || `${id}.webp`;
+    const safeName = sanitizeFileName(original);
+    const ext = getExtension(safeName);
+    if (!ALLOWED_EXTENSIONS.has(ext)) {
+      return { error: errJSON(415, "unsupported file extension") };
+    }
+
+    const mime = file.type ? String(file.type).toLowerCase() : "";
+    if (mime && !ALLOWED_MIME_TYPES.has(mime)) {
+      return { error: errJSON(415, "unsupported mime type") };
+    }
+
+    return {
+      safeName,
+      mime,
+      body: file.stream(),
+      size: file.size,
+    };
+  }
+
+  if (typeof dataUrl === "string" && dataUrl.startsWith("data:")) {
+    const parsed = parseDataUrl(dataUrl);
+    if (!parsed) {
+      return { error: errJSON(400, "invalid data url") };
+    }
+
+    const ext = mimeToExtension(parsed.mime);
+    if (!ALLOWED_EXTENSIONS.has(ext)) {
+      return { error: errJSON(415, "unsupported file extension") };
+    }
+    if (parsed.mime && !ALLOWED_MIME_TYPES.has(parsed.mime)) {
+      return { error: errJSON(415, "unsupported mime type") };
+    }
+
+    const safeName = sanitizeFileName(`${id}${ext}`);
+
+    return {
+      safeName,
+      mime: parsed.mime,
+      body: parsed.bytes,
+      size: parsed.bytes.byteLength,
+    };
+  }
+
+  return { error: errJSON(400, "file is required") };
+}
+
+function getExtension(name: string) {
+  const idx = name.lastIndexOf(".");
+  return idx >= 0 ? name.slice(idx) : "";
+}
+
+function mimeToExtension(mime: string) {
+  const lower = mime?.toLowerCase() ?? "";
+  if (lower.includes("webp")) return ".webp";
+  if (lower.includes("png")) return ".png";
+  if (lower.includes("jpeg") || lower.includes("jpg")) return ".jpg";
+  return ".webp";
+}
+
+function parseDataUrl(dataUrl: string): { mime: string; bytes: Uint8Array } | null {
+  const match = /^data:([^;,]+)?(;base64)?,(.*)$/i.exec(dataUrl);
+  if (!match) return null;
+  const mime = (match[1] || "image/webp").toLowerCase();
+  const isBase64 = !!match[2];
+  const data = match[3] || "";
+  try {
+    if (isBase64) {
+      const binary = atob(data);
+      const len = binary.length;
+      const bytes = new Uint8Array(len);
+      for (let i = 0; i < len; i++) bytes[i] = binary.charCodeAt(i);
+      return { mime, bytes };
+    }
+    const decoded = decodeURIComponent(data);
+    return { mime, bytes: new TextEncoder().encode(decoded) };
+  } catch (e) {
+    return null;
+  }
+}

--- a/js/admin.js
+++ b/js/admin.js
@@ -821,6 +821,9 @@ async function uploadAkyoOnline({ id, name, type, desc, file, adminPassword, dat
     form.set('name', name);
     form.set('type', type);
     form.set('desc', desc);
+    if (dataUrl) {
+        form.set('dataUrl', dataUrl);
+    }
 
     const preparedFile = await prepareWebpFileForUpload({ id, file, dataUrl });
     if (!(preparedFile instanceof File)) {


### PR DESCRIPTION
## Summary
- allow the upload API to reconstruct files from data URLs when edit flows only have base64 image data
- capture the edit-form data URL when posting so the server can fall back if no browser File is present
- keep MIME and extension validation while supporting additional jpg mime values

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d75cb18b288323bc478b4dc8255395