### PR TITLE
Sync finder tabs with admin UI markup

### DIFF
--- a/finder.html
+++ b/finder.html
@@ -101,11 +101,224 @@
             </div>
         </div>
 
-        <!-- admin.htmlの同一タブ内容を利用 -->
-        <!-- このページはadmin.htmlの完全なエイリアスです。変更はadmin.htmlを編集してください。 -->
-        <div id="addTab" class="tab-content bg-white rounded-xl shadow-lg p-6"></div>
-        <div id="editTab" class="tab-content hidden bg-white rounded-xl shadow-lg p-6"></div>
-        <div id="toolsTab" class="tab-content hidden bg-white rounded-xl shadow-lg p-6"></div>
+        <!-- admin.htmlと同一のタブ内容 -->
+        <div id="addTab" class="tab-content bg-white rounded-xl shadow-lg p-6">
+            <h2 class="text-xl font-bold text-gray-800 mb-6">
+                <i class="fas fa-plus-circle text-red-500 mr-2"></i> 新しいAkyoを登録
+            </h2>
+
+            <form onsubmit="handleAddAkyo(event)" class="space-y-4">
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div>
+                        <label class="block text-gray-700 text-sm font-medium mb-1">ID（自動採番）</label>
+                        <div class="flex items-center gap-2">
+                            <input type="text" id="nextIdDisplay"
+                                   class="flex-1 px-3 py-2 bg-gray-100 border border-gray-300 rounded-lg font-mono font-bold"
+                                   disabled>
+                            <span class="text-sm text-gray-500">自動設定</span>
+                        </div>
+                    </div>
+
+                    <div>
+                        <label class="block text-gray-700 text-sm font-medium mb-1">通称</label>
+                        <input type="text" name="nickname"
+                               class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500"
+                               placeholder="例: チョコミントAkyo">
+                    </div>
+
+                    <div>
+                        <label class="block text-gray-700 text-sm font-medium mb-1">アバター名</label>
+                        <input type="text" name="avatarName" required
+                               class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500"
+                               placeholder="例: Akyo origin">
+                    </div>
+
+                    <div>
+                        <label class="block text-gray-700 text-sm font-medium mb-1">属性（カンマ区切り）</label>
+                        <input type="text" name="attribute" required
+                               class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500"
+                               placeholder="例: チョコミント類,ギミック">
+                    </div>
+
+                    <div>
+                        <label class="block text-gray-700 text-sm font-medium mb-1">作者</label>
+                        <input type="text" name="creator" required
+                               class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500"
+                               placeholder="例: ugai">
+                    </div>
+
+                    <div>
+                        <label class="block text-gray-700 text-sm font-medium mb-1">VRChat URL</label>
+                        <input type="url" name="avatarUrl"
+                               class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500"
+                               placeholder="https://vrchat.com/...">
+                    </div>
+                </div>
+
+                <div>
+                    <label class="block text-gray-700 text-sm font-medium mb-1">備考</label>
+                    <textarea name="notes" rows="3"
+                              class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500"
+                              placeholder="Quest対応、特殊機能など"></textarea>
+                </div>
+
+                <!-- 画像アップロード -->
+                <div>
+                    <label class="block text-gray-700 text-sm font-medium mb-1">画像</label>
+                    <div class="drop-zone border-2 border-dashed border-gray-300 rounded-lg p-6 text-center" id="imageDropZone">
+                        <i class="fas fa-cloud-upload-alt text-4xl text-gray-400 mb-2"></i>
+                        <p class="text-gray-600">画像をドラッグ&ドロップ または</p>
+                        <input type="file" id="imageInput" accept=".webp,.png,.jpg,.jpeg" class="hidden">
+                        <button type="button" onclick="document.getElementById('imageInput').click()"
+                                class="mt-2 px-4 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300">
+                            ファイルを選択
+                        </button>
+
+                        <!-- プレビューとトリミングエリア -->
+                        <div id="imagePreview" class="mt-4 hidden">
+                            <div class="bg-gray-100 rounded-lg p-4">
+                                <div class="mb-3 text-sm text-gray-600">
+                                    <i class="fas fa-info-circle mr-1"></i>
+                                    ドラッグで位置調整、スクロールで拡大縮小できます
+                                </div>
+
+                                <!-- トリミングコンテナ -->
+                                <div id="cropContainer" class="relative mx-auto mb-4" style="width: 300px; height: 200px; overflow: hidden; border: 2px solid #4f46e5; border-radius: 8px;">
+                                    <img id="cropImage" src="" alt="Crop preview"
+                                         style="position: absolute; cursor: move; transform-origin: center;">
+                                </div>
+
+                                <!-- コントロールボタン -->
+                                <div class="flex justify-center gap-2">
+                                    <button type="button" onclick="resetImagePosition()"
+                                            class="px-3 py-1 bg-gray-500 text-white rounded hover:bg-gray-600 text-sm">
+                                        <i class="fas fa-redo mr-1"></i> リセット
+                                    </button>
+                                    <button type="button" onclick="zoomImage(1.1)"
+                                            class="px-3 py-1 bg-blue-500 text-white rounded hover:bg-blue-600 text-sm">
+                                        <i class="fas fa-search-plus mr-1"></i> 拡大
+                                    </button>
+                                    <button type="button" onclick="zoomImage(0.9)"
+                                            class="px-3 py-1 bg-blue-500 text-white rounded hover:bg-blue-600 text-sm">
+                                        <i class="fas fa-search-minus mr-1"></i> 縮小
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <!-- 追加: 画像をインターネット上の保存場所にアップロード -->
+                    <div class="mt-3 flex items-center gap-2">
+                        <input id="adminPasswordOnline" type="password" placeholder="管理パスワード（Owner/Admin）" class="border rounded px-3 py-2 w-80">
+                        <button type="button" onclick="uploadAkyoOnlineFromForm()" class="px-4 py-2 rounded-lg bg-emerald-600 text-white hover:bg-emerald-700">
+                            画像を公開用にアップロード
+                        </button>
+                    </div>
+                    <p class="text-xs text-gray-500 mt-1">保存に成功すると、図鑑でもすぐ表示されます（対応形式: WebP / PNG / JPG）。</p>
+                </div>
+
+                <button type="submit" class="w-full bg-gradient-to-r from-green-500 to-blue-500 text-white py-3 rounded-lg font-medium hover:opacity-90 transition-opacity">
+                    <i class="fas fa-save mr-2"></i> 登録する
+                </button>
+            </form>
+        </div>
+
+        <!-- 編集・削除タブ -->
+        <div id="editTab" class="tab-content hidden bg-white rounded-xl shadow-lg p-6">
+            <h2 class="text-xl font-bold text-gray-800 mb-6">
+                <i class="fas fa-edit text-blue-500 mr-2"></i> Akyoの編集・削除
+            </h2>
+
+            <!-- 検索 -->
+            <div class="mb-6">
+                <div class="relative">
+                    <input type="text" id="editSearchInput"
+                           placeholder="ID、名前、属性で検索..."
+                           class="w-full px-4 py-3 pl-12 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500">
+                    <i class="fas fa-search absolute left-4 top-4 text-gray-400"></i>
+                </div>
+            </div>
+
+            <!-- 編集リスト -->
+            <div class="overflow-x-auto">
+                <table class="w-full">
+                    <thead class="bg-gray-100">
+                        <tr>
+                            <th class="px-4 py-3 text-left text-sm font-medium text-gray-700">ID</th>
+                            <th class="px-4 py-3 text-left text-sm font-medium text-gray-700">名前</th>
+                            <th class="px-4 py-3 text-left text-sm font-medium text-gray-700">属性</th>
+                            <th class="px-4 py-3 text-left text-sm font-medium text-gray-700">作者</th>
+                            <th class="px-4 py-3 text-center text-sm font-medium text-gray-700">操作</th>
+                        </tr>
+                    </thead>
+                    <tbody id="editList" class="divide-y divide-gray-200">
+                        <!-- データはJavaScriptで動的に追加 -->
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        <!-- ツールタブ -->
+        <div id="toolsTab" class="tab-content hidden bg-white rounded-xl shadow-lg p-6">
+            <h2 class="text-xl font-bold text-gray-800 mb-6">
+                <i class="fas fa-tools text-orange-500 mr-2"></i> ファインダーツール
+            </h2>
+
+            <div class="space-y-6">
+                <!-- ID再採番ツール -->
+                <div class="border rounded-lg p-4">
+                    <h3 class="font-bold text-lg mb-2 text-gray-800">
+                        <i class="fas fa-sort-numeric-down text-blue-500 mr-2"></i> ID再採番
+                    </h3>
+                    <p class="text-sm text-gray-600 mb-4">
+                        すべてのAkyoのIDを001から連番で振り直します。<br>
+                        ※ 画像とお気に入りの紐付けも自動で更新されます。
+                    </p>
+                    <button onclick="renumberAllIds()" class="px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600">
+                        <i class="fas fa-redo mr-2"></i> ID再採番を実行
+                    </button>
+                </div>
+
+                <!-- CSVインポート -->
+                <div class="border rounded-lg p-4">
+                    <h3 class="font-bold text-lg mb-2 text-gray-800">
+                        <i class="fas fa-file-upload text-orange-500 mr-2"></i> CSVインポート（追加登録）
+                    </h3>
+                    <p class="text-sm text-gray-600 mb-4">
+                        CSVファイルからAkyoデータを追加登録します。アップロード前に最初の数件をプレビューします。<br>
+                        対応形式: .csv（MIME: text/csv, application/vnd.ms-excel, text/plain なども許容）
+                    </p>
+
+                    <!-- ドロップゾーン -->
+                    <div id="csvDropZone" class="drop-zone rounded-lg p-6 text-center mb-4">
+                        <i class="fas fa-cloud-upload-alt text-3xl text-gray-400 mb-2"></i>
+                        <p class="text-gray-600">CSVファイルをドラッグ&ドロップ または</p>
+                        <input type="file" id="csvInput" accept=".csv,text/csv,text/plain,application/vnd.ms-excel" class="hidden">
+                        <button type="button" onclick="document.getElementById('csvInput').click()"
+                                class="mt-2 px-4 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300">
+                            ファイルを選択
+                        </button>
+                    </div>
+
+                    <!-- プレビュー -->
+                    <div id="csvPreview" class="hidden">
+                        <div class="bg-gray-50 rounded-lg p-3 mb-3 text-sm text-gray-600">
+                            ヘッダー行は無視し、既存データの最大IDから自動採番して追加されます。
+                        </div>
+                        <div class="overflow-x-auto border rounded-lg">
+                            <table class="min-w-full text-sm" id="csvPreviewTable"></table>
+                        </div>
+                        <div class="mt-4 flex gap-2">
+                            <button onclick="uploadCSV()" class="px-4 py-2 bg-orange-500 text-white rounded-lg hover:bg-orange-600">
+                                <i class="fas fa-check mr-2"></i> この内容で登録
+                            </button>
+                            <button type="button" onclick="document.getElementById('csvPreview').classList.add('hidden'); document.getElementById('csvInput').value='';" class="px-4 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300">
+                                クリア
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
 
     <!-- 編集モーダル（admin.htmlと共有） -->


### PR DESCRIPTION
## Summary
- embed the full add/edit/tools tab markup from admin.html directly into finder.html
- ensure finder mode exposes the same DOM nodes required by admin.js, enabling search and edit functionality

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d75b8c0df48323bfe0173db5d50cf4