### PR TITLE
Fix duplicated modal initialization blocking Akyo data load

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -704,34 +704,33 @@ function setupEventListeners() {
     }
 
     const detailModal = document.getElementById('detailModal');
-// モーダルの外側クリック/ESCで閉じる（重複防止フラグ）
-const detailModal = document.getElementById('detailModal');
-if (detailModal && !detailModal.dataset.outsideCloseInitialized) {
-    const isEventInsideModal = (event) => {
-        const modalContentContainer = detailModal.querySelector('[data-modal-content]');
-        return modalContentContainer ? modalContentContainer.contains(event.target) : false;
-    };
+    // モーダルの外側クリック/ESCで閉じる（重複防止フラグ）
+    if (detailModal && !detailModal.dataset.outsideCloseInitialized) {
+        const isEventInsideModal = (event) => {
+            const modalContentContainer = detailModal.querySelector('[data-modal-content]');
+            return modalContentContainer ? modalContentContainer.contains(event.target) : false;
+        };
 
-    const handlePointerDownOutsideModal = (event) => {
-        if (detailModal.classList.contains('hidden')) return;
-        if (!isEventInsideModal(event)) {
-            closeModal();
-        }
-    };
+        const handlePointerDownOutsideModal = (event) => {
+            if (detailModal.classList.contains('hidden')) return;
+            if (!isEventInsideModal(event)) {
+                closeModal();
+            }
+        };
 
-    const outsideCloseEvents = window.PointerEvent ? ['pointerdown'] : ['mousedown', 'touchstart'];
-    outsideCloseEvents.forEach((eventName) => {
-        document.addEventListener(eventName, handlePointerDownOutsideModal, true);
-    });
+        const outsideCloseEvents = window.PointerEvent ? ['pointerdown'] : ['mousedown', 'touchstart'];
+        outsideCloseEvents.forEach((eventName) => {
+            document.addEventListener(eventName, handlePointerDownOutsideModal, true);
+        });
 
-    document.addEventListener('keydown', (event) => {
-        if (event.key === 'Escape' && !detailModal.classList.contains('hidden')) {
-            closeModal();
-        }
-    });
+        document.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape' && !detailModal.classList.contains('hidden')) {
+                closeModal();
+            }
+        });
 
-    detailModal.dataset.outsideCloseInitialized = 'true';
-}
+        detailModal.dataset.outsideCloseInitialized = 'true';
+    }
 
 
 


### PR DESCRIPTION
## Summary
- remove the duplicate detail modal declaration that caused a syntax error in main.js
- ensure the modal outside-click handler is only initialized once while keeping the logic scoped to setupEventListeners

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d76386aab48323a11fa12672b148ab