### PR TITLE
Handle favorites storage parsing failure on load

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -12,6 +12,19 @@ let adminSessionToken = null; // 認証ワードはメモリ内にのみ保持
 const FINDER_PREFILL_VALUE = 'Akyo';
 const isFinderModePage = typeof window !== 'undefined' && window.location.pathname.endsWith('finder.html');
 
+function loadFavoritesArray() {
+    try {
+        const raw = localStorage.getItem('akyoFavorites');
+        if (!raw) return [];
+        const parsed = JSON.parse(raw);
+        return Array.isArray(parsed) ? parsed : [];
+    } catch (error) {
+        console.warn('Failed to parse favorites for admin tools. Resetting storage.', error);
+        try { localStorage.removeItem('akyoFavorites'); } catch (_) {}
+        return [];
+    }
+}
+
 function applyFinderRegistrationDefaults({ force = false } = {}) {
     if (!(isFinderModePage || currentUserRole === 'finder')) return;
 
@@ -1248,7 +1261,7 @@ async function deleteAkyo(akyoId) {
     localStorage.setItem('akyoImages', JSON.stringify(imageDataMap));
 
     // お気に入りデータのID更新
-    let favorites = JSON.parse(localStorage.getItem('akyoFavorites')) || [];
+    let favorites = loadFavoritesArray();
     favorites = favorites
         .filter(id => id !== akyoId)  // 削除対象を除外
         .map(id => oldToNewIdMap[id] || id);  // ID更新
@@ -2037,7 +2050,7 @@ async function renumberAllIds() {
     localStorage.setItem('akyoImages', JSON.stringify(imageDataMap));
 
     // お気に入りデータのID更新
-    let favorites = JSON.parse(localStorage.getItem('akyoFavorites')) || [];
+    let favorites = loadFavoritesArray();
     favorites = favorites.map(oldId => oldToNewIdMap[oldId]).filter(Boolean);
     localStorage.setItem('akyoFavorites', JSON.stringify(favorites));
 

--- a/js/main.js
+++ b/js/main.js
@@ -22,7 +22,20 @@ let akyoData = [];
 window.publicAkyoList = akyoData;
 let filteredData = [];
 let searchIndex = []; // { id, text }
-let favorites = JSON.parse(localStorage.getItem('akyoFavorites')) || [];
+function loadFavoritesFromStorage() {
+    try {
+        const raw = localStorage.getItem('akyoFavorites');
+        if (!raw) return [];
+        const parsed = JSON.parse(raw);
+        return Array.isArray(parsed) ? parsed : [];
+    } catch (error) {
+        console.warn('Failed to parse favorites from localStorage. Resetting storage.', error);
+        try { localStorage.removeItem('akyoFavorites'); } catch (_) {}
+        return [];
+    }
+}
+
+let favorites = loadFavoritesFromStorage();
 let serverCsvRowCount = 0; // /api/csv が返す期待行数（ヘッダで受け取り）
 // 行末ダングリング引用符などの単純な破損を自動修復
 function sanitizeCsvText(text){
@@ -732,7 +745,7 @@ function setupEventListeners() {
         detailModal.dataset.outsideCloseInitialized = 'true';
     }
 
-
+    }
 
 // 正規化（ひらがな/カタカナ/全角半角）
 function normalizeForSearch(input) {


### PR DESCRIPTION
## Summary
- guard parsing of the akyoFavorites entry so the index page can load even when storage is empty or corrupted
- close the setupEventListeners block correctly to restore script execution
- reuse the safe favorites parsing helper inside the admin tools to avoid the same crash when the list is empty

## Testing
- node --check js/main.js
- node --check js/admin.js

------
https://chatgpt.com/codex/tasks/task_e_68d76a9598c483238297fe1508b960b0