### PR TITLE
Refine admin image storage and attribute normalization

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -134,14 +134,17 @@
         <!-- タブナビゲーション -->
         <div class="bg-white rounded-xl shadow-lg mb-6">
             <div class="flex border-b">
-                <button onclick="switchTab('add')" class="tab-btn px-6 py-4 font-medium text-gray-700 hover:text-red-600 border-b-2 border-red-500" data-tab="add">
-                    <i class="fas fa-plus-circle mr-2"></i> 新規登録
+                <button onclick="switchTab('add')" class="tab-btn tab-active px-6 py-4 font-medium text-gray-700" data-tab="add">
+                    <i class="fas fa-plus-circle"></i>
+                    新規登録
                 </button>
-                <button onclick="switchTab('edit')" class="tab-btn px-6 py-4 font-medium text-gray-700 hover:text-red-600 border-b-2 border-transparent" data-tab="edit">
-                    <i class="fas fa-edit mr-2"></i> 編集・削除
+                <button onclick="switchTab('edit')" class="tab-btn px-6 py-4 font-medium text-gray-700" data-tab="edit">
+                    <i class="fas fa-edit"></i>
+                    編集・削除
                 </button>
-                <button onclick="switchTab('tools')" class="tab-btn px-6 py-4 font-medium text-gray-700 hover:text-red-600 border-b-2 border-transparent" data-tab="tools">
-                    <i class="fas fa-tools mr-2"></i> ツール
+                <button onclick="switchTab('tools')" class="tab-btn px-6 py-4 font-medium text-gray-700" data-tab="tools">
+                    <i class="fas fa-tools"></i>
+                    ツール
                 </button>
             </div>
         </div>
@@ -149,47 +152,82 @@
         <!-- 新規登録タブ -->
         <div id="addTab" class="tab-content bg-white rounded-xl shadow-lg p-6">
             <h2 class="text-xl font-bold text-gray-800 mb-6">
-                <i class="fas fa-plus-circle text-red-500 mr-2"></i> 新しいAkyoを登録
+                <i class="fas fa-plus-circle admin-accent-text mr-2"></i> 新しいAkyoを登録
             </h2>
 
             <form onsubmit="handleAddAkyo(event)" class="space-y-4">
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <div>
                         <label class="block text-gray-700 text-sm font-medium mb-1">ID（自動採番）</label>
-                        <div class="flex items-center gap-2">
-                            <input type="text" id="nextIdDisplay"
-                                   class="flex-1 px-3 py-2 bg-gray-100 border border-gray-300 rounded-lg font-mono font-bold"
-                                   disabled>
-                            <span class="text-sm text-gray-500">自動設定</span>
-                        </div>
+                        <input type="text" id="nextIdDisplay"
+                               class="w-full px-3 py-2 bg-gray-100 border border-gray-300 rounded-lg font-mono font-bold"
+                               disabled>
+                        <p class="mt-2 text-xs text-gray-500 leading-snug">
+                            画像IDの自動割り当てはローカルに保存された画像を優先的に参照し、未使用の番号（CSV未登録の画像も含む）から決定されます。
+                        </p>
                     </div>
 
                     <div>
-                        <label class="block text-gray-700 text-sm font-medium mb-1">通称</label>
-                        <input type="text" name="nickname"
-                               class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500"
+                        <div class="flex items-center justify-between gap-2">
+                            <label class="block text-gray-700 text-sm font-medium">通称</label>
+                            <button type="button" id="checkNicknameDuplicateButton"
+                                    class="inline-flex items-center gap-2 px-3 py-1.5 text-sm border border-orange-200 text-orange-700 bg-orange-50 rounded-lg hover:bg-orange-100 transition-colors">
+                                <i class="fas fa-search"></i>
+                                同じ通称が既に登録されているか確認
+                            </button>
+                        </div>
+                        <input type="text" name="nickname" id="addNicknameInput"
+                               class="mt-2 w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500"
                                placeholder="例: チョコミントAkyo">
+                        <p id="nicknameDuplicateStatus" class="mt-2 text-sm hidden" data-status-base-class="mt-2 text-sm" aria-live="polite"></p>
                     </div>
 
                     <div>
                         <label class="block text-gray-700 text-sm font-medium mb-1">アバター名</label>
-                        <input type="text" name="avatarName" required
+                        <input type="text" name="avatarName" id="addAvatarNameInput" required
                                class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500"
                                placeholder="例: Akyo origin">
+                        <div class="mt-2 flex flex-col sm:flex-row sm:items-center gap-2">
+                            <button type="button" id="checkAvatarDuplicateButton"
+                                    class="inline-flex items-center gap-2 px-3 py-1.5 text-sm border border-orange-200 text-orange-700 bg-orange-50 rounded-lg hover:bg-orange-100 transition-colors">
+                                <i class="fas fa-search"></i>
+                                同じアバター名が既に登録されているか確認
+                            </button>
+                            <p id="avatarDuplicateStatus" class="text-sm hidden mt-1 sm:mt-0 sm:ml-2" data-status-base-class="text-sm mt-1 sm:mt-0 sm:ml-2" aria-live="polite"></p>
+                        </div>
                     </div>
 
                     <div>
-                        <label class="block text-gray-700 text-sm font-medium mb-1">属性（カンマ区切り）</label>
-                        <input type="text" name="attribute" required
-                               class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500"
-                               placeholder="例: チョコミント類,ギミック">
+                        <label class="block text-gray-700 text-sm font-medium mb-1">属性</label>
+                        <div class="space-y-2">
+                            <button type="button"
+                                    class="w-full flex items-center justify-center gap-2 px-3 py-2 bg-green-100 text-green-800 border border-green-300 rounded-lg hover:bg-green-200 transition-colors"
+                                    data-attribute-target="add">
+                                <i class="fas fa-tags"></i>
+                                属性を管理
+                            </button>
+                            <input type="hidden" name="attribute" id="addAttributeInput">
+                            <div class="border border-dashed border-green-200 rounded-lg bg-white/60 p-3">
+                                <p id="addAttributePlaceholder" class="text-sm text-gray-500">
+                                    選択された属性がここに表示されます
+                                </p>
+                                <div id="addAttributeList"
+                                     class="hidden mt-2 flex flex-wrap gap-2 max-h-32 overflow-y-auto pr-1"
+                                     role="list"></div>
+                            </div>
+                        </div>
                     </div>
 
                     <div>
                         <label class="block text-gray-700 text-sm font-medium mb-1">作者</label>
-                        <input type="text" name="creator" required
-                               class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500"
-                               placeholder="例: ugai">
+                        <div class="relative" data-author-autocomplete>
+                            <input type="text" name="creator" id="addCreatorInput" required
+                                   class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500"
+                                   placeholder="例: ugai" autocomplete="off">
+                            <div id="addCreatorSuggestions"
+                                 class="hidden absolute left-0 right-0 mt-1 bg-white border border-gray-200 rounded-lg shadow-lg max-h-48 overflow-y-auto z-30"
+                                 role="listbox" aria-label="既存の作者から選択" aria-hidden="true"></div>
+                        </div>
                     </div>
 
                     <div>
@@ -385,6 +423,77 @@
         </div>
     </div>
 
+    <!-- 属性管理モーダル -->
+    <div id="attributeModal" class="fixed inset-0 z-50 hidden" role="dialog" aria-modal="true" aria-labelledby="attributeModalTitle">
+        <div class="absolute inset-0 bg-black/40" data-attribute-overlay></div>
+        <div class="relative mx-auto my-10 w-full max-w-3xl px-4">
+            <div class="bg-white rounded-2xl shadow-2xl overflow-hidden">
+                <div class="flex items-center justify-between px-6 py-4 border-b border-gray-200 bg-gradient-to-r from-green-50 to-emerald-50">
+                    <h3 id="attributeModalTitle" class="text-lg font-bold text-gray-800 flex items-center gap-2">
+                        <i class="fas fa-tags text-green-500"></i>
+                        属性を管理
+                    </h3>
+                    <button type="button" class="text-gray-500 hover:text-gray-700" data-attribute-close>
+                        <span class="sr-only">閉じる</span>
+                        <i class="fas fa-times text-xl"></i>
+                    </button>
+                </div>
+
+                <div class="px-6 py-5 space-y-5">
+                    <div class="flex flex-col sm:flex-row gap-3">
+                        <div class="relative flex-1">
+                            <i class="fas fa-search absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"></i>
+                            <input type="search" id="attributeSearchInput"
+                                   class="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
+                                   placeholder="属性を検索">
+                        </div>
+                        <button type="button" id="attributeCreateStart"
+                                class="inline-flex items-center justify-center gap-2 px-4 py-2 rounded-lg border border-green-300 bg-green-100 text-green-800 hover:bg-green-200 transition-colors">
+                            <i class="fas fa-plus-circle"></i>
+                            新しい属性を作成
+                        </button>
+                    </div>
+
+                    <div id="attributeCreateForm" class="hidden bg-green-50 border border-green-200 rounded-xl p-4 space-y-3">
+                        <div>
+                            <label for="attributeNewInput" class="block text-sm font-medium text-green-900 mb-1">新しい属性名</label>
+                            <input type="text" id="attributeNewInput"
+                                   class="w-full px-3 py-2 border border-green-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
+                                   placeholder="例: チョコミント類">
+                        </div>
+                        <div class="flex items-center justify-end gap-2">
+                            <button type="button" id="attributeCreateCancel"
+                                    class="px-4 py-2 rounded-lg border border-gray-300 text-gray-600 hover:bg-gray-100">
+                                キャンセル
+                            </button>
+                            <button type="button" id="attributeCreateConfirm"
+                                    class="px-4 py-2 rounded-lg bg-green-500 text-white hover:bg-green-600">
+                                追加する
+                            </button>
+                        </div>
+                    </div>
+
+                    <div class="border border-gray-200 rounded-2xl">
+                        <div id="attributeListScroll" class="max-h-72 overflow-y-auto pr-1" tabindex="0">
+                            <div id="attributeListGrid" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2 p-3"></div>
+                        </div>
+                        <p id="attributeEmptyMessage" class="hidden px-4 pb-4 text-sm text-gray-500">一致する属性がありません。</p>
+                    </div>
+                </div>
+
+                <div class="px-6 py-4 bg-gray-50 border-t border-gray-200 flex flex-col sm:flex-row items-stretch sm:items-center justify-end gap-3">
+                    <button type="button" class="px-4 py-2 rounded-lg border border-gray-300 text-gray-600 hover:bg-gray-100" data-attribute-close>
+                        キャンセル
+                    </button>
+                    <button type="button" id="attributeApplyButton"
+                            class="px-5 py-2 rounded-lg bg-gradient-to-r from-green-500 to-emerald-500 text-white font-semibold shadow hover:opacity-90 transition-opacity">
+                        選択を決定
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <script src="js/image-manifest-loader.js"></script>
     <script src="js/image-loader.js"></script>
     <script>
@@ -392,6 +501,7 @@
             if (window.loadAkyoManifest) { window.loadAkyoManifest().catch(() => {}); }
         });
     </script>
+    <script src="js/attribute-manager.js"></script>
     <script src="js/admin.js"></script>
 
     <script>

--- a/css/kid-friendly.css
+++ b/css/kid-friendly.css
@@ -22,6 +22,20 @@
     /* カードの影 */
     --card-shadow: 0 4px 6px rgba(0, 0, 0, 0.1), 0 2px 4px rgba(0, 0, 0, 0.06);
     --card-hover-shadow: 0 10px 25px rgba(0, 0, 0, 0.15), 0 6px 10px rgba(0, 0, 0, 0.1);
+
+    /* タブアクセント */
+    --tab-accent-color: var(--primary-pink);
+    --tab-accent-text: #e14783;
+
+    /* 属性モーダル */
+    --attribute-accent: var(--primary-green);
+    --attribute-accent-strong: #2f855a;
+    --attribute-accent-soft: rgba(102, 217, 165, 0.18);
+    --attribute-border: rgba(102, 217, 165, 0.45);
+    --attribute-border-soft: rgba(102, 217, 165, 0.28);
+    --attribute-shadow: rgba(102, 217, 165, 0.3);
+    --attribute-chip-bg: rgba(102, 217, 165, 0.18);
+    --attribute-chip-border: rgba(102, 217, 165, 0.35);
 }
 
 /* 全体のフォント設定 - 丸みを帯びたフォント */
@@ -150,6 +164,89 @@ button, .btn {
     transition: all 0.3s ease !important;
     text-transform: none !important;
     letter-spacing: 0 !important;
+}
+
+.attribute-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.35rem 0.85rem;
+    border-radius: 9999px;
+    background: rgba(102, 178, 255, 0.2);
+    color: #3451a1;
+    box-shadow: 0 6px 12px rgba(102, 178, 255, 0.2);
+    font-weight: 700;
+    letter-spacing: 0.01em;
+}
+
+.tab-btn {
+    border-bottom-width: 2px !important;
+    border-color: transparent !important;
+    color: var(--text-secondary) !important;
+    transition: color 0.2s ease, border-color 0.2s ease;
+}
+
+.tab-btn:hover {
+    color: var(--tab-accent-text) !important;
+}
+
+.tab-btn.tab-active {
+    border-color: var(--tab-accent-color) !important;
+    color: var(--tab-accent-text) !important;
+    font-weight: 800 !important;
+}
+
+.admin-accent-text {
+    color: var(--primary-pink) !important;
+}
+
+.attribute-option {
+    border: 1px solid var(--attribute-border-soft);
+    background: #ffffff;
+}
+
+.attribute-option--inactive:hover {
+    border-color: var(--attribute-border);
+    background: var(--attribute-accent-soft);
+}
+
+.attribute-option--active {
+    border-color: var(--attribute-border);
+    background: var(--attribute-accent-soft);
+}
+
+.attribute-option__indicator {
+    border: 1px solid transparent;
+    color: transparent;
+    transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.attribute-option__indicator--inactive {
+    border-color: #d1d5db;
+}
+
+.attribute-option__indicator--active {
+    background: var(--attribute-accent);
+    color: #ffffff;
+    box-shadow: 0 6px 16px var(--attribute-shadow);
+}
+
+.attribute-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.25rem 0.55rem;
+    border-radius: 9999px;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    background: var(--attribute-chip-bg);
+    color: var(--attribute-accent-strong);
+    border: 1px solid var(--attribute-chip-border);
+}
+
+.attribute-chip--session {
+    text-transform: uppercase;
 }
 
 /* プライマリボタン */

--- a/finder.html
+++ b/finder.html
@@ -27,32 +27,336 @@
     <script src="js/storage-adapter.js"></script>
 
     <style>
-        body { font-family: 'Noto Sans JP', 'Kosugi Maru', sans-serif; }
-        .loading-spinner { border: 4px solid #f3f3f3; border-top: 4px solid #667eea; border-radius: 50%; width: 40px; height: 40px; animation: spin 1s linear infinite; }
-        @keyframes spin { 0% { transform: rotate(0deg); } 100% { transform: rotate(360deg); } }
-        .drop-zone { border: 2px dashed #cbd5e0; transition: all 0.3s; }
-        .drop-zone.dragover { border-color: #667eea; background-color: #f7fafc; }
+        :root {
+            color-scheme: light;
+        }
+
+        body.finder-body {
+            --finder-accent: #ef4444;
+            --finder-accent-strong: #dc2626;
+            --finder-accent-secondary: #f97316;
+            --finder-accent-soft: #fff4ed;
+            --finder-accent-soft-border: #fecaca;
+            --finder-surface: #ffffff;
+            --finder-surface-muted: #fff7f3;
+            --finder-text-primary: #1f2937;
+            --finder-text-secondary: #4b5563;
+            --finder-divider: #fde8e8;
+            --finder-header-shadow: 0 18px 32px rgba(249, 115, 22, 0.22);
+            --tab-accent-color: var(--finder-accent);
+            --tab-accent-text: var(--finder-accent-strong);
+            --attribute-accent: var(--finder-accent);
+            --attribute-accent-strong: var(--finder-accent-strong);
+            --attribute-accent-soft: var(--finder-accent-soft);
+            --attribute-border: rgba(239, 68, 68, 0.45);
+            --attribute-border-soft: rgba(249, 115, 22, 0.22);
+            --attribute-shadow: rgba(249, 115, 22, 0.28);
+            --attribute-chip-bg: rgba(249, 115, 22, 0.12);
+            --attribute-chip-border: rgba(249, 115, 22, 0.24);
+
+            font-family: 'Noto Sans JP', 'Kosugi Maru', sans-serif;
+            background:
+                radial-gradient(120% 120% at 0% 0%, rgba(249, 115, 22, 0.18), transparent 55%),
+                radial-gradient(140% 140% at 100% 0%, rgba(239, 68, 68, 0.14), transparent 60%),
+                linear-gradient(180deg, #fff7f3 0%, #fff1ec 45%, #fffdf9 100%);
+            color: var(--finder-text-primary);
+        }
+
+        .finder-header {
+            background: linear-gradient(135deg, rgba(220, 38, 38, 0.95), rgba(249, 115, 22, 0.92));
+            backdrop-filter: saturate(160%) blur(8px);
+            box-shadow: var(--finder-header-shadow);
+        }
+
+        .finder-logo {
+            background: linear-gradient(140deg, #f87171, #f97316);
+            box-shadow: 0 12px 24px rgba(249, 115, 22, 0.32);
+        }
+
+        .finder-header-badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.35rem;
+            padding: 0.35rem 0.75rem;
+            border-radius: 9999px;
+            background: rgba(255, 255, 255, 0.18);
+            color: #fff;
+            font-weight: 600;
+        }
+
+        .finder-header-btn {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.4rem;
+            padding: 0.5rem 0.85rem;
+            border-radius: 0.9rem;
+            background: rgba(255, 255, 255, 0.16);
+            color: #ffffff;
+            font-weight: 600;
+            transition: background 0.2s ease, transform 0.2s ease;
+        }
+
+        .finder-header-btn:hover {
+            background: rgba(255, 255, 255, 0.28);
+            transform: translateY(-1px);
+        }
+
+        .finder-header-btn:focus-visible,
+        .finder-primary-btn:focus-visible,
+        .finder-secondary-btn:focus-visible,
+        .finder-mini-btn:focus-visible,
+        .finder-chip-button:focus-visible,
+        .finder-ghost-btn:focus-visible,
+        .finder-apply-btn:focus-visible {
+            outline: 3px solid rgba(255, 255, 255, 0);
+            box-shadow: 0 0 0 3px rgba(249, 115, 22, 0.35);
+        }
+
+        .finder-primary-btn {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.5rem;
+            background: linear-gradient(135deg, var(--finder-accent), var(--finder-accent-secondary));
+            color: #fff;
+            border-radius: 0.9rem;
+            font-weight: 600;
+            padding: 0.75rem 1rem;
+            box-shadow: 0 14px 24px rgba(249, 115, 22, 0.25);
+            transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+        }
+
+        .finder-primary-btn:hover {
+            transform: translateY(-1px);
+            box-shadow: 0 16px 28px rgba(249, 115, 22, 0.3);
+            opacity: 0.95;
+        }
+
+        .finder-secondary-btn {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.5rem;
+            border-radius: 0.85rem;
+            border: 1px solid rgba(255, 255, 255, 0.35);
+            color: #fff;
+            padding: 0.45rem 0.9rem;
+            font-weight: 600;
+            transition: background 0.2s ease, color 0.2s ease;
+        }
+
+        .finder-secondary-btn:hover {
+            background: rgba(255, 255, 255, 0.18);
+        }
+
+        .finder-mini-btn {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.35rem;
+            background: var(--finder-accent);
+            color: #fff;
+            border-radius: 0.75rem;
+            padding: 0.35rem 0.85rem;
+            font-weight: 600;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+
+        .finder-mini-btn:hover {
+            transform: translateY(-0.5px);
+            box-shadow: 0 6px 16px rgba(249, 115, 22, 0.25);
+        }
+
+        .finder-card {
+            background: var(--finder-surface);
+            border-radius: 1.25rem;
+            box-shadow: 0 14px 28px rgba(148, 163, 184, 0.18);
+        }
+
+        .finder-card-border {
+            border: 1px solid rgba(249, 115, 22, 0.08);
+        }
+
+        .tab-btn {
+            border-bottom-width: 2px !important;
+            border-color: transparent !important;
+            color: var(--finder-text-secondary) !important;
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            transition: color 0.2s ease, border-color 0.2s ease;
+        }
+
+        .tab-btn:hover {
+            color: var(--finder-accent-strong) !important;
+        }
+
+        .tab-btn.tab-active {
+            border-color: var(--tab-accent-color) !important;
+            color: var(--tab-accent-text) !important;
+            font-weight: 700 !important;
+        }
+
+        .loading-spinner {
+            border: 4px solid rgba(239, 68, 68, 0.15);
+            border-top: 4px solid var(--finder-accent);
+            border-radius: 50%;
+            width: 40px;
+            height: 40px;
+            animation: spin 1s linear infinite;
+        }
+
+        @keyframes spin {
+            0% { transform: rotate(0deg); }
+            100% { transform: rotate(360deg); }
+        }
+
+        .drop-zone {
+            border: 2px dashed var(--finder-accent-soft-border);
+            background: var(--finder-surface);
+            transition: border-color 0.2s ease, background-color 0.2s ease;
+        }
+
+        .drop-zone.dragover {
+            border-color: var(--finder-accent);
+            background-color: var(--finder-accent-soft);
+        }
+
+        .finder-section-title {
+            color: var(--finder-text-primary);
+        }
+
+        .finder-accent-text {
+            color: var(--finder-accent-strong);
+        }
+
+        .finder-badge-container {
+            border: 1px dashed var(--finder-accent-soft-border);
+            background: rgba(249, 115, 22, 0.05);
+        }
+
+        .attribute-badge {
+            background: rgba(249, 115, 22, 0.12);
+            color: var(--finder-accent-strong);
+            border-radius: 9999px;
+            font-weight: 600;
+            padding: 0.2rem 0.75rem;
+            font-size: 0.85rem;
+        }
+
+        .finder-modal-header {
+            background: linear-gradient(135deg, rgba(254, 243, 199, 0.9), rgba(254, 226, 226, 0.9));
+        }
+
+        .finder-modal-title {
+            color: var(--finder-text-primary);
+        }
+
+        .finder-modal-accent {
+            color: var(--finder-accent-strong);
+        }
+
+        .finder-modal-search {
+            border-color: var(--finder-accent-soft-border);
+        }
+
+        .finder-modal-search:focus {
+            border-color: var(--finder-accent);
+            box-shadow: 0 0 0 3px rgba(249, 115, 22, 0.16);
+        }
+
+        .finder-modal-create {
+            border: 1px solid var(--finder-accent-soft-border);
+            background: rgba(249, 115, 22, 0.08);
+        }
+
+        .finder-modal-create label {
+            color: var(--finder-accent-strong);
+        }
+
+        .finder-modal-create-input {
+            border-color: var(--finder-accent-soft-border);
+        }
+
+        .finder-modal-create-input:focus {
+            border-color: var(--finder-accent);
+            box-shadow: 0 0 0 3px rgba(249, 115, 22, 0.18);
+        }
+
+        .finder-modal-scroll {
+            border: 1px solid var(--finder-divider);
+        }
+
+        .finder-modal-footer {
+            background: rgba(254, 242, 242, 0.9);
+        }
+
+        .finder-chip-button {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.4rem;
+            border: 1px solid var(--finder-accent-soft-border);
+            background: rgba(249, 115, 22, 0.08);
+            color: var(--finder-accent-strong);
+            border-radius: 0.85rem;
+            padding: 0.6rem 1.05rem;
+            font-weight: 600;
+        }
+
+        .finder-chip-button:hover {
+            background: rgba(249, 115, 22, 0.16);
+        }
+
+        .finder-ghost-btn {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.4rem;
+            border: 1px solid rgba(249, 115, 22, 0.25);
+            color: var(--finder-accent-strong);
+            border-radius: 0.9rem;
+            padding: 0.55rem 1.1rem;
+            font-weight: 600;
+        }
+
+        .finder-ghost-btn:hover {
+            background: rgba(249, 115, 22, 0.08);
+        }
+
+        .finder-apply-btn {
+            background: linear-gradient(135deg, var(--finder-accent), var(--finder-accent-secondary));
+            color: #fff;
+            box-shadow: 0 16px 30px rgba(249, 115, 22, 0.25);
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+
+        .finder-apply-btn:hover {
+            transform: translateY(-1px);
+            box-shadow: 0 18px 34px rgba(249, 115, 22, 0.3);
+        }
     </style>
 </head>
-<body class="bg-gradient-to-br from-gray-100 to-gray-200 min-h-screen">
+<body class="finder-body min-h-screen">
     <!-- ヘッダー -->
-    <header class="bg-gray-900 text-white shadow-lg sticky top-0 z-40">
+    <header class="finder-header text-white sticky top-0 z-40">
         <div class="container mx-auto px-4 py-4">
             <div class="flex items-center justify-between">
                 <div class="flex items-center gap-3">
-                    <div class="w-10 h-10 bg-gradient-to-r from-red-500 to-orange-500 rounded-full flex items-center justify-center">
+                    <div class="w-10 h-10 finder-logo rounded-full flex items-center justify-center">
                         <i class="fas fa-shield-alt text-white"></i>
                     </div>
                     <h1 class="text-2xl font-bold">Akyoずかん ファインダーモード</h1>
                 </div>
 
                 <div class="flex items-center gap-2">
-                    <span id="userRole" class="hidden px-3 py-2 rounded-lg bg-gray-700 text-white text-sm"></span>
-                    <button onclick="location.href='index.html'" class="px-3 py-2 rounded-lg bg-gray-700 hover:bg-gray-600 text-white text-sm" id="backBtn">
-                        <i class="fas fa-home mr-1"></i> 図鑑に戻る
+                    <span id="userRole" class="hidden finder-header-badge text-sm"></span>
+                    <button onclick="location.href='index.html'" class="finder-header-btn text-sm" id="backBtn">
+                        <i class="fas fa-home"></i>
+                        図鑑に戻る
                     </button>
-                    <button onclick="logout()" class="hidden px-3 py-2 rounded-lg bg-gray-700 hover:bg-gray-600 text-white text-sm" id="logoutBtn">
-                        <i class="fas fa-sign-out-alt mr-1"></i> ログアウト
+                    <button onclick="logout()" class="hidden finder-header-btn text-sm" id="logoutBtn">
+                        <i class="fas fa-sign-out-alt"></i>
+                        ログアウト
                     </button>
                 </div>
             </div>
@@ -63,7 +367,7 @@
     <div id="loginScreen" class="flex items-center justify-center min-h-[calc(100vh-80px)]">
         <div class="bg-white rounded-2xl shadow-2xl p-8 max-w-md w-full mx-4">
             <div class="text-center mb-8">
-                <div class="w-20 h-20 bg-gradient-to-r from-red-500 to-orange-500 rounded-full flex items-center justify-center mx-auto mb-4">
+                <div class="w-20 h-20 finder-logo rounded-full flex items-center justify-center mx-auto mb-4">
                     <i class="fas fa-lock text-white text-3xl"></i>
                 </div>
                 <h2 class="text-2xl font-bold text-gray-800 mb-2">ファインダー認証</h2>
@@ -73,10 +377,11 @@
             <form id="finderLoginForm">
                 <div class="mb-6">
                     <label class="block text-gray-700 text-sm font-medium mb-2">Akyoワード</label>
-                    <input type="password" id="passwordInput" name="password" autocomplete="current-password" class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500" placeholder="Akyoワードを入力" required>
+                    <input type="password" id="passwordInput" name="password" autocomplete="current-password" class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:border-indigo-400" placeholder="Akyoワードを入力" required>
                 </div>
-                <button type="submit" class="w-full bg-gradient-to-r from-red-500 to-orange-500 text-white py-3 rounded-lg font-medium hover:opacity-90 transition-opacity">
-                    <i class="fas fa-sign-in-alt mr-2"></i> ログイン
+                <button type="submit" class="finder-primary-btn w-full">
+                    <i class="fas fa-sign-in-alt"></i>
+                    ログイン
                 </button>
                 <div id="loginError" class="hidden mt-4 p-3 bg-red-100 text-red-700 rounded-lg text-sm" role="alert" aria-live="assertive">
                     <i class="fas fa-exclamation-circle mr-1"></i> Akyoワードが正しくありません
@@ -87,70 +392,87 @@
 
     <!-- ファインダー画面（admin.htmlと同一構成） -->
     <div id="adminScreen" class="hidden container mx-auto px-4 py-8">
-        <div class="bg-white rounded-xl shadow-lg mb-6">
+        <div class="bg-white rounded-xl shadow-lg mb-6 finder-card-border">
             <div class="flex border-b">
-                <button onclick="switchTab('add')" class="tab-btn px-6 py-4 font-medium text-gray-700 hover:text-red-600 border-b-2 border-red-500" data-tab="add">
-                    <i class="fas fa-plus-circle mr-2"></i> 新規登録
+                <button onclick="switchTab('add')" class="tab-btn tab-active px-6 py-4 font-medium" data-tab="add">
+                    <i class="fas fa-plus-circle"></i>
+                    新規登録
                 </button>
-                <button onclick="switchTab('edit')" class="tab-btn px-6 py-4 font-medium text-gray-700 hover:text-red-600 border-b-2 border-transparent" data-tab="edit">
-                    <i class="fas fa-edit mr-2"></i> 編集・削除
+                <button onclick="switchTab('edit')" class="tab-btn px-6 py-4 font-medium" data-tab="edit">
+                    <i class="fas fa-edit"></i>
+                    編集・削除
                 </button>
-                <button onclick="switchTab('tools')" class="tab-btn px-6 py-4 font-medium text-gray-700 hover:text-red-600 border-b-2 border-transparent" data-tab="tools">
-                    <i class="fas fa-tools mr-2"></i> ツール
+                <button onclick="switchTab('tools')" class="tab-btn px-6 py-4 font-medium" data-tab="tools">
+                    <i class="fas fa-tools"></i>
+                    ツール
                 </button>
             </div>
         </div>
 
         <!-- admin.htmlと同一のタブ内容 -->
-        <div id="addTab" class="tab-content bg-white rounded-xl shadow-lg p-6">
+        <div id="addTab" class="tab-content bg-white rounded-xl shadow-lg p-6 finder-card-border">
             <h2 class="text-xl font-bold text-gray-800 mb-6">
-                <i class="fas fa-plus-circle text-red-500 mr-2"></i> 新しいAkyoを登録
+                <i class="fas fa-plus-circle finder-accent-text mr-2"></i> 新しいAkyoを登録
             </h2>
 
             <form onsubmit="handleAddAkyo(event)" class="space-y-4">
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <div>
                         <label class="block text-gray-700 text-sm font-medium mb-1">ID（自動採番）</label>
-                        <div class="flex items-center gap-2">
-                            <input type="text" id="nextIdDisplay"
-                                   class="flex-1 px-3 py-2 bg-gray-100 border border-gray-300 rounded-lg font-mono font-bold"
-                                   disabled>
-                            <span class="text-sm text-gray-500">自動設定</span>
-                        </div>
+                        <input type="text" id="nextIdDisplay"
+                               class="w-full px-3 py-2 bg-gray-100 border border-gray-300 rounded-lg font-mono font-bold"
+                               disabled>
+                        <p class="mt-2 text-xs text-gray-500 leading-snug">
+                            画像IDの自動割り当てはローカルに保存済みの画像を基準に未使用の番号を選びます（CSVに未登録の画像も対象）。
+                        </p>
                     </div>
 
                     <div>
                         <label class="block text-gray-700 text-sm font-medium mb-1">通称</label>
                         <input type="text" name="nickname"
-                               class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500"
+                               class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:border-indigo-400"
                                placeholder="例: チョコミントAkyo">
                     </div>
 
                     <div>
                         <label class="block text-gray-700 text-sm font-medium mb-1">アバター名</label>
                         <input type="text" name="avatarName" required
-                               class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500"
+                               class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:border-indigo-400"
                                placeholder="例: Akyo origin">
                     </div>
 
                     <div>
-                        <label class="block text-gray-700 text-sm font-medium mb-1">属性（カンマ区切り）</label>
-                        <input type="text" name="attribute" required
-                               class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500"
-                               placeholder="例: チョコミント類,ギミック">
+                        <label class="block text-gray-700 text-sm font-medium mb-1">属性</label>
+                        <div class="space-y-2">
+                            <button type="button"
+                                    class="w-full flex items-center justify-center gap-2 px-3 py-2 finder-chip-button rounded-lg transition-colors"
+                                    data-attribute-target="add">
+                                <i class="fas fa-tags"></i>
+                                属性を管理
+                            </button>
+                            <input type="hidden" name="attribute" id="addAttributeInput">
+                            <div class="finder-badge-container rounded-lg p-3">
+                                <p id="addAttributePlaceholder" class="text-sm text-gray-500">
+                                    選択された属性がここに表示されます
+                                </p>
+                                <div id="addAttributeList"
+                                     class="hidden mt-2 flex flex-wrap gap-2 max-h-32 overflow-y-auto pr-1"
+                                     role="list"></div>
+                            </div>
+                        </div>
                     </div>
 
                     <div>
                         <label class="block text-gray-700 text-sm font-medium mb-1">作者</label>
                         <input type="text" name="creator" required
-                               class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500"
+                               class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:border-indigo-400"
                                placeholder="例: ugai">
                     </div>
 
                     <div>
                         <label class="block text-gray-700 text-sm font-medium mb-1">VRChat URL</label>
                         <input type="url" name="avatarUrl"
-                               class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500"
+                               class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:border-indigo-400"
                                placeholder="https://vrchat.com/...">
                     </div>
                 </div>
@@ -158,7 +480,7 @@
                 <div>
                     <label class="block text-gray-700 text-sm font-medium mb-1">備考</label>
                     <textarea name="notes" rows="3"
-                              class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500"
+                              class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:border-indigo-400"
                               placeholder="Quest対応、特殊機能など"></textarea>
                 </div>
 
@@ -192,15 +514,17 @@
                                 <div class="flex justify-center gap-2">
                                     <button type="button" onclick="resetImagePosition()"
                                             class="px-3 py-1 bg-gray-500 text-white rounded hover:bg-gray-600 text-sm">
-                                        <i class="fas fa-redo mr-1"></i> リセット
+                                        <i class="fas fa-redo"></i> リセット
                                     </button>
                                     <button type="button" onclick="zoomImage(1.1)"
-                                            class="px-3 py-1 bg-blue-500 text-white rounded hover:bg-blue-600 text-sm">
-                                        <i class="fas fa-search-plus mr-1"></i> 拡大
+                                            class="finder-mini-btn text-sm">
+                                        <i class="fas fa-search-plus"></i>
+                                        拡大
                                     </button>
                                     <button type="button" onclick="zoomImage(0.9)"
-                                            class="px-3 py-1 bg-blue-500 text-white rounded hover:bg-blue-600 text-sm">
-                                        <i class="fas fa-search-minus mr-1"></i> 縮小
+                                            class="finder-mini-btn text-sm">
+                                        <i class="fas fa-search-minus"></i>
+                                        縮小
                                     </button>
                                 </div>
                             </div>
@@ -209,16 +533,17 @@
                     <p class="text-xs text-gray-500 mt-3">登録すると画像も公開環境へ自動でアップロードされ、図鑑でもすぐ表示されます（対応形式: WebP / PNG / JPG）。</p>
                 </div>
 
-                <button type="submit" class="w-full bg-gradient-to-r from-green-500 to-blue-500 text-white py-3 rounded-lg font-medium hover:opacity-90 transition-opacity">
-                    <i class="fas fa-save mr-2"></i> 登録する
+                <button type="submit" class="finder-primary-btn w-full">
+                    <i class="fas fa-save"></i>
+                    登録する
                 </button>
             </form>
         </div>
 
         <!-- 編集・削除タブ -->
-        <div id="editTab" class="tab-content hidden bg-white rounded-xl shadow-lg p-6">
+        <div id="editTab" class="tab-content hidden bg-white rounded-xl shadow-lg p-6 finder-card-border">
             <h2 class="text-xl font-bold text-gray-800 mb-6">
-                <i class="fas fa-edit text-blue-500 mr-2"></i> Akyoの編集・削除
+                <i class="fas fa-edit finder-accent-text mr-2"></i> Akyoの編集・削除
             </h2>
 
             <!-- 検索 -->
@@ -226,7 +551,7 @@
                 <div class="relative">
                     <input type="text" id="editSearchInput"
                            placeholder="ID、名前、属性で検索..."
-                           class="w-full px-4 py-3 pl-12 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500">
+                           class="w-full px-4 py-3 pl-12 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:border-indigo-400">
                     <i class="fas fa-search absolute left-4 top-4 text-gray-400"></i>
                 </div>
             </div>
@@ -251,30 +576,31 @@
         </div>
 
         <!-- ツールタブ -->
-        <div id="toolsTab" class="tab-content hidden bg-white rounded-xl shadow-lg p-6">
+        <div id="toolsTab" class="tab-content hidden bg-white rounded-xl shadow-lg p-6 finder-card-border">
             <h2 class="text-xl font-bold text-gray-800 mb-6">
-                <i class="fas fa-tools text-orange-500 mr-2"></i> ファインダーツール
+                <i class="fas fa-tools finder-accent-text mr-2"></i> ファインダーツール
             </h2>
 
             <div class="space-y-6">
                 <!-- ID再採番ツール -->
-                <div class="border rounded-lg p-4">
+                <div class="finder-card-border rounded-lg p-4 bg-white">
                     <h3 class="font-bold text-lg mb-2 text-gray-800">
-                        <i class="fas fa-sort-numeric-down text-blue-500 mr-2"></i> ID再採番
+                        <i class="fas fa-sort-numeric-down finder-accent-text mr-2"></i> ID再採番
                     </h3>
                     <p class="text-sm text-gray-600 mb-4">
                         すべてのAkyoのIDを001から連番で振り直します。<br>
                         ※ 画像とお気に入りの紐付けも自動で更新されます。
                     </p>
-                    <button onclick="renumberAllIds()" class="px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600">
-                        <i class="fas fa-redo mr-2"></i> ID再採番を実行
+                    <button onclick="renumberAllIds()" class="finder-primary-btn">
+                        <i class="fas fa-redo"></i>
+                        ID再採番を実行
                     </button>
                 </div>
 
                 <!-- CSVインポート -->
-                <div class="border rounded-lg p-4">
+                <div class="finder-card-border rounded-lg p-4 bg-white">
                     <h3 class="font-bold text-lg mb-2 text-gray-800">
-                        <i class="fas fa-file-upload text-orange-500 mr-2"></i> CSVインポート（追加登録）
+                        <i class="fas fa-file-upload finder-accent-text mr-2"></i> CSVインポート（追加登録）
                     </h3>
                     <p class="text-sm text-gray-600 mb-4">
                         CSVファイルからAkyoデータを追加登録します。アップロード前に最初の数件をプレビューします。<br>
@@ -301,8 +627,9 @@
                             <table class="min-w-full text-sm" id="csvPreviewTable"></table>
                         </div>
                         <div class="mt-4 flex gap-2">
-                            <button onclick="uploadCSV()" class="px-4 py-2 bg-orange-500 text-white rounded-lg hover:bg-orange-600">
-                                <i class="fas fa-check mr-2"></i> この内容で登録
+                            <button onclick="uploadCSV()" class="finder-primary-btn">
+                                <i class="fas fa-check"></i>
+                                この内容で登録
                             </button>
                             <button type="button" onclick="document.getElementById('csvPreview').classList.add('hidden'); document.getElementById('csvInput').value='';" class="px-4 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300">
                                 クリア
@@ -330,6 +657,77 @@
         </div>
     </div>
 
+    <!-- 属性管理モーダル -->
+    <div id="attributeModal" class="fixed inset-0 z-50 hidden" role="dialog" aria-modal="true" aria-labelledby="attributeModalTitle">
+        <div class="absolute inset-0 bg-black/40" data-attribute-overlay></div>
+        <div class="relative mx-auto my-10 w-full max-w-3xl px-4">
+            <div class="bg-white rounded-2xl shadow-2xl overflow-hidden finder-card-border">
+                <div class="flex items-center justify-between px-6 py-4 border-b border-gray-200 finder-modal-header">
+                    <h3 id="attributeModalTitle" class="text-lg font-bold finder-modal-title flex items-center gap-2">
+                        <i class="fas fa-tags finder-modal-accent"></i>
+                        属性を管理
+                    </h3>
+                    <button type="button" class="text-gray-500 hover:text-gray-700" data-attribute-close>
+                        <span class="sr-only">閉じる</span>
+                        <i class="fas fa-times text-xl"></i>
+                    </button>
+                </div>
+
+                <div class="px-6 py-5 space-y-5">
+                    <div class="flex flex-col sm:flex-row gap-3">
+                        <div class="relative flex-1">
+                            <i class="fas fa-search absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"></i>
+                            <input type="search" id="attributeSearchInput"
+                                   class="w-full pl-10 pr-4 py-2 border rounded-lg focus:outline-none finder-modal-search focus:ring-0"
+                                   placeholder="属性を検索">
+                        </div>
+                        <button type="button" id="attributeCreateStart"
+                                class="inline-flex items-center justify-center gap-2 px-4 py-2 rounded-lg finder-chip-button transition-colors">
+                            <i class="fas fa-plus-circle"></i>
+                            新しい属性を作成
+                        </button>
+                    </div>
+
+                    <div id="attributeCreateForm" class="hidden finder-modal-create rounded-xl p-4 space-y-3">
+                        <div>
+                            <label for="attributeNewInput" class="block text-sm font-medium mb-1">新しい属性名</label>
+                            <input type="text" id="attributeNewInput"
+                                   class="w-full px-3 py-2 border rounded-lg focus:outline-none finder-modal-create-input"
+                                   placeholder="例: チョコミント類">
+                        </div>
+                        <div class="flex items-center justify-end gap-2">
+                            <button type="button" id="attributeCreateCancel"
+                                    class="px-4 py-2 rounded-lg border border-gray-300 text-gray-600 hover:bg-gray-100">
+                            キャンセル
+                            </button>
+                            <button type="button" id="attributeCreateConfirm"
+                                    class="px-4 py-2 rounded-lg finder-primary-btn">
+                                追加する
+                            </button>
+                        </div>
+                    </div>
+
+                    <div class="finder-modal-scroll rounded-2xl">
+                        <div id="attributeListScroll" class="max-h-72 overflow-y-auto pr-1" tabindex="0">
+                            <div id="attributeListGrid" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2 p-3"></div>
+                        </div>
+                        <p id="attributeEmptyMessage" class="hidden px-4 pb-4 text-sm text-gray-500">一致する属性がありません。</p>
+                    </div>
+                </div>
+
+                <div class="px-6 py-4 border-t border-gray-200 finder-modal-footer flex flex-col sm:flex-row items-stretch sm:items-center justify-end gap-3">
+                    <button type="button" class="px-4 py-2 rounded-lg finder-ghost-btn bg-white" data-attribute-close>
+                        キャンセル
+                    </button>
+                    <button type="button" id="attributeApplyButton"
+                            class="px-5 py-2 rounded-lg finder-apply-btn font-semibold">
+                        選択を決定
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <script src="js/image-manifest-loader.js"></script>
     <script src="js/image-loader.js"></script>
     <script>
@@ -337,6 +735,7 @@
             if (window.loadAkyoManifest) { window.loadAkyoManifest().catch(() => {}); }
         });
     </script>
+    <script src="js/attribute-manager.js"></script>
     <script src="js/admin.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {

--- a/js/admin.js
+++ b/js/admin.js
@@ -11,6 +11,522 @@ let adminSessionToken = null; // 認証ワードはメモリ内にのみ保持
 let hasBoundActionDelegation = false;
 
 const FINDER_PREFILL_VALUE = 'Akyo';
+const DEFAULT_ATTRIBUTE_NAME = '未分類';
+
+const attributeManagerApi = window.attributeManager;
+if (!attributeManagerApi) {
+    throw new Error('attributeManager module failed to load. Please ensure js/attribute-manager.js is loaded before js/admin.js');
+}
+
+attributeManagerApi.configure({
+    notify: (message, type = 'info', options) => showNotification(message, type, options),
+    confirmDelete: (message) => window.confirm(message),
+    getCurrentRole: () => currentUserRole,
+    canDelete: (meta, role) => {
+        const name = typeof meta?.name === 'string' ? meta.name.trim() : '';
+        if (name === DEFAULT_ATTRIBUTE_NAME) {
+            return false;
+        }
+        return meta?.isSession ? true : role === 'owner';
+    },
+    onDelete: handleAttributeDeletion,
+    onAttributesChanged: () => {
+        // No-op for now; hook reserved for future analytics or persistence triggers.
+    },
+});
+
+async function persistImage(akyoId, dataUrl, { backupToLocalStorage = true } = {}) {
+    if (!akyoId) {
+        throw new Error('persistImage requires a target ID');
+    }
+    if (!dataUrl) {
+        throw new Error('persistImage requires image data');
+    }
+
+    if (!imageDataMap || typeof imageDataMap !== 'object') {
+        imageDataMap = {};
+    }
+
+    const hadExistingEntry = Object.prototype.hasOwnProperty.call(imageDataMap, akyoId);
+    const previousDataUrl = imageDataMap[akyoId];
+    imageDataMap[akyoId] = dataUrl;
+
+    const revertCache = () => {
+        if (hadExistingEntry) {
+            imageDataMap[akyoId] = previousDataUrl;
+        } else {
+            delete imageDataMap[akyoId];
+        }
+    };
+
+    let persistedToIndexedDb = false;
+    let indexedDbError = null;
+
+    try {
+        if (window.saveSingleImage) {
+            await window.saveSingleImage(akyoId, dataUrl);
+            persistedToIndexedDb = true;
+        } else if (window.storageManager && window.storageManager.isIndexedDBAvailable) {
+            await window.storageManager.init();
+            await window.storageManager.saveImage(akyoId, dataUrl);
+            persistedToIndexedDb = true;
+        }
+    } catch (error) {
+        indexedDbError = error;
+        console.debug('persistImage: indexed storage failed', akyoId, error);
+    }
+
+    if (indexedDbError && !persistedToIndexedDb) {
+        revertCache();
+        throw indexedDbError;
+    }
+
+    if (backupToLocalStorage) {
+        try {
+            localStorage.setItem('akyoImages', JSON.stringify(imageDataMap));
+        } catch (error) {
+            if (error && error.name === 'QuotaExceededError' && !persistedToIndexedDb) {
+                revertCache();
+                throw error;
+            }
+            console.debug('persistImage: localStorage backup failed', akyoId, error);
+        }
+    }
+
+    return { persistedToIndexedDb };
+}
+
+async function removeImagePersistent(akyoId) {
+    if (!akyoId) {
+        return;
+    }
+
+    let removalError = null;
+    let localBackupWarning = null;
+
+    if (window.deleteSingleImage) {
+        try {
+            await window.deleteSingleImage(akyoId);
+        } catch (error) {
+            removalError = error;
+        }
+    }
+
+    if (removalError) {
+        throw removalError;
+    }
+
+    if (window.storageManager && window.storageManager.isIndexedDBAvailable) {
+        try {
+            await window.storageManager.init();
+            await window.storageManager.deleteImage(akyoId);
+        } catch (error) {
+            console.debug('removeImagePersistent: indexed storage delete failed', akyoId, error);
+        }
+    }
+
+    if (imageDataMap && typeof imageDataMap === 'object') {
+        delete imageDataMap[akyoId];
+    }
+
+    try {
+        localStorage.setItem('akyoImages', JSON.stringify(imageDataMap));
+    } catch (error) {
+        if (error && error.name === 'QuotaExceededError') {
+            localBackupWarning = error;
+        } else {
+            console.debug('removeImagePersistent: localStorage update failed', akyoId, error);
+        }
+    }
+
+    return { localBackupWarning };
+}
+
+const authorSuggestionState = {
+    authors: [],
+    isBound: false,
+    isOpen: false,
+    lastFilter: '',
+    handleDocumentClick: null,
+    hasDelegatedEvents: false,
+    boundInput: null,
+};
+
+function rebuildCreatorSuggestionSource() {
+    const uniqueCreators = new Set();
+    if (Array.isArray(akyoData)) {
+        akyoData.forEach((akyo) => {
+            const value = typeof akyo?.creator === 'string' ? akyo.creator.trim() : '';
+            if (value) {
+                uniqueCreators.add(value);
+            }
+        });
+    }
+
+    const sorted = Array.from(uniqueCreators);
+    sorted.sort((a, b) => a.localeCompare(b, 'ja'));
+
+    authorSuggestionState.authors = sorted;
+
+    if (authorSuggestionState.isOpen) {
+        renderCreatorSuggestions(authorSuggestionState.lastFilter);
+    }
+}
+
+function bindCreatorSuggestionInput() {
+    if (authorSuggestionState.isBound) {
+        return;
+    }
+
+    const input = document.getElementById('addCreatorInput');
+    const panel = document.getElementById('addCreatorSuggestions');
+
+    if (!input || !panel) {
+        return;
+    }
+
+    authorSuggestionState.boundInput = input;
+
+    const handleInput = () => {
+        if (authorSuggestionState.isOpen) {
+            renderCreatorSuggestions(input.value || '');
+        } else {
+            showCreatorSuggestions();
+        }
+    };
+
+    input.addEventListener('focus', showCreatorSuggestions);
+    input.addEventListener('click', showCreatorSuggestions);
+    input.addEventListener('input', handleInput);
+    input.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape') {
+            hideCreatorSuggestions();
+        } else if (event.key === 'ArrowDown') {
+            const firstOption = panel.querySelector('button');
+            if (firstOption) {
+                event.preventDefault();
+                showCreatorSuggestions();
+                window.requestAnimationFrame(() => firstOption.focus());
+            }
+        }
+    });
+    input.addEventListener('blur', () => {
+        window.requestAnimationFrame(() => {
+            const active = document.activeElement;
+            if (!panel.contains(active)) {
+                hideCreatorSuggestions();
+            }
+        });
+    });
+
+    if (!authorSuggestionState.hasDelegatedEvents) {
+        const handlePanelPointer = (event) => {
+            const option = event.target.closest('[data-author-option]');
+            if (!option) {
+                return;
+            }
+            const targetInput = authorSuggestionState.boundInput;
+            if (!targetInput) {
+                return;
+            }
+            event.preventDefault();
+            const value = option.dataset.authorOption || '';
+            targetInput.value = value;
+            hideCreatorSuggestions();
+            targetInput.dispatchEvent(new Event('input', { bubbles: true }));
+            window.requestAnimationFrame(() => targetInput.focus());
+        };
+
+        const handlePanelKeydown = (event) => {
+            if (event.key === 'Escape') {
+                hideCreatorSuggestions();
+                window.requestAnimationFrame(() => input.focus());
+                return;
+            }
+
+            if (event.key !== 'Enter' && event.key !== ' ') {
+                return;
+            }
+
+            const option = event.target.closest('[data-author-option]');
+            if (!option) {
+                return;
+            }
+
+            event.preventDefault();
+            const targetInput = authorSuggestionState.boundInput;
+            if (!targetInput) {
+                return;
+            }
+
+            const value = option.dataset.authorOption || '';
+            targetInput.value = value;
+            hideCreatorSuggestions();
+            window.requestAnimationFrame(() => targetInput.focus());
+        };
+
+        panel.addEventListener('mousedown', handlePanelPointer);
+        panel.addEventListener('keydown', handlePanelKeydown);
+        authorSuggestionState.hasDelegatedEvents = true;
+    }
+
+    authorSuggestionState.handleDocumentClick = (event) => {
+        if (!authorSuggestionState.isOpen) {
+            return;
+        }
+        if (event.target === input || panel.contains(event.target)) {
+            return;
+        }
+        hideCreatorSuggestions();
+    };
+
+    document.addEventListener('mousedown', authorSuggestionState.handleDocumentClick);
+
+    authorSuggestionState.isBound = true;
+}
+
+function showCreatorSuggestions() {
+    const input = document.getElementById('addCreatorInput');
+    const panel = document.getElementById('addCreatorSuggestions');
+    if (!input || !panel) {
+        return;
+    }
+
+    renderCreatorSuggestions(input.value || '');
+
+    panel.classList.remove('hidden');
+    panel.setAttribute('aria-hidden', 'false');
+    authorSuggestionState.isOpen = true;
+}
+
+function hideCreatorSuggestions() {
+    const panel = document.getElementById('addCreatorSuggestions');
+    if (!panel) {
+        return;
+    }
+
+    panel.classList.add('hidden');
+    panel.setAttribute('aria-hidden', 'true');
+    authorSuggestionState.isOpen = false;
+}
+
+function renderCreatorSuggestions(filterText = '') {
+    const panel = document.getElementById('addCreatorSuggestions');
+    const input = document.getElementById('addCreatorInput');
+
+    if (!panel || !input) {
+        return;
+    }
+
+    panel.setAttribute('role', 'listbox');
+    authorSuggestionState.lastFilter = filterText;
+
+    const normalized = filterText.trim().toLocaleLowerCase('ja');
+    const allAuthors = authorSuggestionState.authors || [];
+    const matches = normalized
+        ? allAuthors.filter((author) => author.toLocaleLowerCase('ja').includes(normalized))
+        : allAuthors;
+
+    panel.textContent = '';
+    panel.scrollTop = 0;
+
+    if (allAuthors.length === 0) {
+        const empty = document.createElement('p');
+        empty.className = 'px-3 py-2 text-sm text-gray-500';
+        empty.textContent = '登録済みの作者がまだありません';
+        panel.appendChild(empty);
+        return;
+    }
+
+    if (matches.length === 0) {
+        const noMatch = document.createElement('p');
+        noMatch.className = 'px-3 py-2 text-sm text-gray-500';
+        noMatch.textContent = '一致する作者が見つかりません';
+        panel.appendChild(noMatch);
+        return;
+    }
+
+    const fragment = document.createDocumentFragment();
+    matches.forEach((author) => {
+        const option = document.createElement('button');
+        option.type = 'button';
+        option.className = 'w-full text-left px-3 py-2 text-sm hover:bg-green-100 focus:bg-green-100 focus:outline-none';
+        option.setAttribute('role', 'option');
+        option.dataset.authorOption = author;
+        option.textContent = author;
+        fragment.appendChild(option);
+    });
+
+    panel.appendChild(fragment);
+}
+
+async function handleAttributeDeletion({ name, meta }) {
+    const parsed = attributeManagerApi.parseAttributeString(name);
+    const normalized = parsed.length > 0 ? parsed[0] : '';
+    if (!normalized) {
+        return false;
+    }
+
+    if (normalized === DEFAULT_ATTRIBUTE_NAME) {
+        showNotification(`属性「${DEFAULT_ATTRIBUTE_NAME}」は削除できません`, 'error');
+        return false;
+    }
+
+    let csvUpdated = false;
+    const touchedRecords = [];
+
+    if (!meta?.isSession && Array.isArray(akyoData) && akyoData.length > 0) {
+        akyoData.forEach((akyo) => {
+            const attributeValue = typeof akyo?.attribute === 'string' ? akyo.attribute : '';
+            const attrs = attributeManagerApi.parseAttributeString(attributeValue);
+            if (!attrs.includes(normalized)) {
+                return;
+            }
+
+            const filtered = attrs.filter(attr => attr !== normalized);
+            if (filtered.length === 0) {
+                filtered.push(DEFAULT_ATTRIBUTE_NAME);
+            }
+            const updatedValue = filtered.join(',');
+            if (updatedValue !== attributeValue) {
+                touchedRecords.push({ akyo, original: attributeValue, updated: updatedValue });
+            }
+        });
+
+        if (touchedRecords.length > 0) {
+            touchedRecords.forEach(({ akyo, updated }) => {
+                akyo.attribute = updated;
+            });
+
+            try {
+                await updateCSVFile();
+                csvUpdated = true;
+            } catch (error) {
+                touchedRecords.forEach(({ akyo, original }) => {
+                    akyo.attribute = original;
+                });
+                console.error('Failed to persist attribute removal', error);
+                showNotification('属性の削除内容を保存できませんでした', 'error');
+                refreshDerivedCollections();
+                return false;
+            }
+        }
+    }
+
+    if (csvUpdated) {
+        try {
+            updateEditList();
+        } catch (_) {
+            // 編集リストが未初期化の場合は無視
+        }
+    }
+
+    refreshDerivedCollections();
+
+    return { message: `属性「${normalized}」を削除しました`, type: 'success' };
+}
+
+function refreshDerivedCollections() {
+    attributeManagerApi.rebuildFromAkyoData(akyoData);
+    rebuildCreatorSuggestionSource();
+}
+
+function normalizeForDuplicateComparison(value) {
+    if (typeof value !== 'string') {
+        return '';
+    }
+    return value.trim().toLocaleLowerCase('ja');
+}
+
+function findDuplicateIdsByField(fieldName, value, { excludeId } = {}) {
+    const target = normalizeForDuplicateComparison(value);
+    if (!target || !Array.isArray(akyoData)) {
+        return [];
+    }
+
+    return akyoData.reduce((matches, entry) => {
+        if (!entry || (excludeId && entry.id === excludeId)) {
+            return matches;
+        }
+
+        const candidate = normalizeForDuplicateComparison(entry[fieldName]);
+        if (candidate && candidate === target) {
+            matches.push(entry.id);
+        }
+        return matches;
+    }, []);
+}
+
+function formatAkyoIdLabel(id) {
+    const numeric = Number.parseInt(id, 10);
+    if (Number.isFinite(numeric)) {
+        return `#${String(numeric).padStart(3, '0')}`;
+    }
+    return `#${String(id)}`;
+}
+
+function setDuplicateStatus(element, { message, tone }) {
+    if (!element) {
+        return;
+    }
+
+    const baseClass = element.dataset.statusBaseClass ? element.dataset.statusBaseClass.trim() : '';
+    if (!message) {
+        const hiddenClass = baseClass ? `${baseClass} hidden` : 'hidden';
+        element.className = hiddenClass;
+        element.textContent = '';
+        return;
+    }
+
+    let toneClass = 'text-gray-600';
+    if (tone === 'error') {
+        toneClass = 'text-red-600';
+    } else if (tone === 'success') {
+        toneClass = 'text-green-600';
+    }
+
+    const className = baseClass ? `${baseClass} ${toneClass}` : toneClass;
+    element.className = className;
+    element.textContent = message;
+}
+
+function clearDuplicateStatus(element) {
+    setDuplicateStatus(element, { message: '', tone: 'neutral' });
+}
+
+function attachDuplicateChecker({ button, input, status, field, texts, excludeId }) {
+    if (!button || !input || !status) {
+        return;
+    }
+
+    const { empty, success, duplicatePrefix } = texts || {};
+
+    const runCheck = () => {
+        const rawValue = input.value || '';
+        if (!rawValue.trim()) {
+            setDuplicateStatus(status, { message: empty || '値を入力してください', tone: 'neutral' });
+            return;
+        }
+
+        const matches = findDuplicateIdsByField(field, rawValue, { excludeId });
+        if (matches.length === 0) {
+            setDuplicateStatus(status, { message: success || '重複は見つかりませんでした', tone: 'success' });
+            return;
+        }
+
+        const formatted = matches.map(formatAkyoIdLabel).join('、');
+        setDuplicateStatus(status, {
+            message: `${duplicatePrefix || '重複が見つかりました: '}${formatted}`,
+            tone: 'error',
+        });
+    };
+
+    button.addEventListener('click', runCheck);
+
+    const resetHandler = () => clearDuplicateStatus(status);
+    input.addEventListener('input', resetHandler);
+    input.addEventListener('change', resetHandler);
+}
 
 function getMaxAssignedAkyoId() {
     const akyoIds = Array.isArray(akyoData)
@@ -51,6 +567,11 @@ function escapeHtml(value) {
         '`': '&#96;',
     };
     return String(value).replace(/[&<>"'`]/g, (char) => escapeMap[char] || char);
+}
+
+function escapeCsvValue(value) {
+    const str = value === null || value === undefined ? '' : String(value);
+    return /[",\n]/.test(str) ? `"${str.replace(/"/g, '""')}"` : str;
 }
 
 function loadFavoritesArray() {
@@ -152,6 +673,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     setupEventListeners();
     setupDragDrop();
+    attributeManagerApi.init();
 
     // DOMの検査（欠落は警告表示）
     verifyRequiredDom();
@@ -195,6 +717,11 @@ function hasUnsavedWork() {
 // ESCで編集モーダルを閉じる
 document.addEventListener('keydown', (event) => {
     if (event.key === 'Escape') {
+        if (attributeManagerApi.isModalOpen()) {
+            event.preventDefault();
+            attributeManagerApi.closeModal();
+            return;
+        }
         const modal = document.getElementById('editModal');
         if (modal && !modal.classList.contains('hidden')) {
             closeEditModal();
@@ -244,6 +771,8 @@ function setupEventListeners() {
         loginForm.addEventListener('submit', handleLogin);
     }
 
+    bindCreatorSuggestionInput();
+
     // トリミングUIの有無を検出
     const useCustomCropper = !!document.getElementById('cropContainer');
 
@@ -271,6 +800,30 @@ function setupEventListeners() {
         // 初期表示で全件を表示（空文字検索）
         setTimeout(() => searchForEdit(), 0);
     }
+
+    attachDuplicateChecker({
+        button: document.getElementById('checkNicknameDuplicateButton'),
+        input: document.getElementById('addNicknameInput'),
+        status: document.getElementById('nicknameDuplicateStatus'),
+        field: 'nickname',
+        texts: {
+            empty: '通称を入力してください',
+            success: '重複している通称はありません',
+            duplicatePrefix: '重複している通称が見つかりました: ',
+        },
+    });
+
+    attachDuplicateChecker({
+        button: document.getElementById('checkAvatarDuplicateButton'),
+        input: document.getElementById('addAvatarNameInput'),
+        status: document.getElementById('avatarDuplicateStatus'),
+        field: 'avatarName',
+        texts: {
+            empty: 'アバター名を入力してください',
+            success: '重複しているアバター名はありません',
+            duplicatePrefix: '重複しているアバター名が見つかりました: ',
+        },
+    });
 
     if (!hasBoundActionDelegation) {
         document.addEventListener('click', handleAdminActionClick);
@@ -517,6 +1070,8 @@ async function loadAkyoData() {
 
         console.debug(`データ読み込み完了: Akyo ${akyoData.length}件, 画像 ${Object.keys(imageDataMap).length}件`);
 
+        refreshDerivedCollections();
+
         // 各関数の実行前に要素の存在を確認
         if (document.getElementById('editList')) {
             updateEditList();
@@ -567,6 +1122,8 @@ async function loadAkyoData() {
 
         console.debug('CSVなし、画像データのみで動作');
 
+        refreshDerivedCollections();
+
         // 各関数の実行前に要素の存在を確認
         if (document.getElementById('editList')) {
             updateEditList();
@@ -583,18 +1140,29 @@ async function loadAkyoData() {
 // CSV解析（main.jsと同じロジック）
 function parseCSV(csvText) {
     // CRLF正規化
-    csvText = String(csvText).replace(/\r\n/g, '\n');
+    csvText = String(csvText).replace(/\r\n?/g, '\n');
     const data = [];
     let inQuotes = false;
     let field = '';
     let record = [];
     let lineIndex = 0;
-    const pushField = () => { record.push(field.trim()); field = ''; };
+    const pushField = () => { record.push(field); field = ''; };
     const pushRecord = () => {
         if (record.length > 0) {
             // ヘッダ行はスキップ
             if (lineIndex > 0) {
-                const values = record;
+                const rawValues = record;
+                const values = rawValues.map((val, index) => {
+                    if (val === null || val === undefined) {
+                        return '';
+                    }
+                    const str = String(val);
+                    // 備考欄（index 5）はトリムせずそのまま保持
+                    if (index === 5) {
+                        return str;
+                    }
+                    return str.trim();
+                });
                 if (values[0] && /^\d{3}$/.test(values[0])) {
                     const akyo = {
                         id: values[0] || '',
@@ -606,18 +1174,19 @@ function parseCSV(csvText) {
                         creator: '',
                         avatarUrl: ''
                     };
+                    const attributeSource = values[4] && values[4].trim() ? values[4] : DEFAULT_ATTRIBUTE_NAME;
                     if (values.length === 8) {
-                        akyo.attribute = values[4] || '未分類';
+                        akyo.attribute = attributeManagerApi.serializeAttributes(attributeSource);
                         akyo.notes = values[5] || '';
                         akyo.creator = values[6] || '不明';
                         akyo.avatarUrl = values[7] || '';
                     } else if (values.length > 8) {
                         akyo.avatarUrl = values[values.length - 1] || '';
                         akyo.creator = values[values.length - 2] || '不明';
-                        akyo.attribute = values[4] || '未分類';
+                        akyo.attribute = attributeManagerApi.serializeAttributes(attributeSource);
                         akyo.notes = values.slice(5, values.length - 2).join(',');
                     } else {
-                        akyo.attribute = values[4] || '未分類';
+                        akyo.attribute = attributeManagerApi.serializeAttributes(attributeSource);
                         akyo.notes = values[5] || '';
                         akyo.creator = values[6] || '不明';
                         akyo.avatarUrl = values[7] || '';
@@ -660,8 +1229,7 @@ function switchTab(tabName) {
 
     // すべてのタブボタンのスタイルをリセット
     document.querySelectorAll('.tab-btn').forEach(btn => {
-        btn.classList.remove('border-red-500');
-        btn.classList.add('border-transparent');
+        btn.classList.remove('tab-active');
     });
 
     // 選択されたタブを表示
@@ -681,8 +1249,7 @@ function switchTab(tabName) {
 
     const targetBtn = document.querySelector(`[data-tab="${tabName}"]`);
     if (targetBtn) {
-        targetBtn.classList.remove('border-transparent');
-        targetBtn.classList.add('border-red-500');
+        targetBtn.classList.add('tab-active');
     }
 
     if (tabName === 'add') {
@@ -706,7 +1273,14 @@ window.switchTab = switchTab;
 async function handleAddAkyo(event) {
     event.preventDefault();
 
+    if (!attributeManagerApi.hasSelection('add')) {
+        showNotification('属性を1つ以上選択してください', 'error');
+        return;
+    }
+
     const formData = new FormData(event.target);
+    const rawAttribute = formData.get('attribute');
+    const normalizedAttribute = attributeManagerApi.serializeAttributes(rawAttribute);
 
     // ID自動採番（データ/画像の双方で最大値+1）
     const maxId = getMaxAssignedAkyoId();
@@ -717,7 +1291,7 @@ async function handleAddAkyo(event) {
         appearance: '',
         nickname: formData.get('nickname'),
         avatarName: formData.get('avatarName'),
-        attribute: formData.get('attribute'),
+        attribute: normalizedAttribute,
         notes: formData.get('notes'),
         creator: formData.get('creator'),
         avatarUrl: formData.get('avatarUrl')
@@ -732,51 +1306,40 @@ async function handleAddAkyo(event) {
 
     // CSV更新
     await updateCSVFile();
+    refreshDerivedCollections();
 
     let latestImageDataUrl = null;
 
-    // トリミングした画像を保存
+    const persistNewImage = async (dataUrl) => {
+        if (!dataUrl) {
+            return;
+        }
+        latestImageDataUrl = dataUrl;
+        try {
+            await persistImage(newAkyo.id, dataUrl);
+        } catch (error) {
+            console.error('Image save error:', error);
+            if (error && error.name === 'QuotaExceededError') {
+                showNotification('容量不足！migrate-storage.htmlでIndexedDBへ移行してください', 'error');
+            } else {
+                showNotification(`画像の保存に失敗しました: ${error?.message || error}`, 'error');
+            }
+        }
+    };
+
     try {
         if (window.generateCroppedImage) {
             const croppedImage = await window.generateCroppedImage();
-            if (croppedImage) {
-                imageDataMap[newAkyo.id] = croppedImage;
-                latestImageDataUrl = croppedImage;
-
-                // IndexedDBに保存を試みる
-                try {
-                    if (window.storageManager && window.storageManager.isIndexedDBAvailable) {
-                        await window.storageManager.init();
-                        await window.storageManager.saveImage(newAkyo.id, croppedImage);
-                    }
-                } catch (e) {
-                    console.debug('IndexedDB save failed, using localStorage');
-                }
-
-                // LocalStorageにも保存（バックアップ）
-                localStorage.setItem('akyoImages', JSON.stringify(imageDataMap));
-            }
+            await persistNewImage(croppedImage);
         } else {
-            // フォールバック: 元の画像をそのまま保存
             const imagePreview = document.querySelector('#cropImage');
-            if (imagePreview && imagePreview.src && imagePreview.src !== window.location.href) {
-                imageDataMap[newAkyo.id] = imagePreview.src;
-                latestImageDataUrl = imagePreview.src;
-
-                try {
-                    if (window.storageManager && window.storageManager.isIndexedDBAvailable) {
-                        await window.storageManager.init();
-                        await window.storageManager.saveImage(newAkyo.id, imagePreview.src);
-                    }
-                } catch (e) {
-                    console.debug('IndexedDB save failed, using localStorage');
-                }
-
-                localStorage.setItem('akyoImages', JSON.stringify(imageDataMap));
-            }
+            const previewSrc = imagePreview && imagePreview.src && imagePreview.src !== window.location.href
+                ? imagePreview.src
+                : null;
+            await persistNewImage(previewSrc);
         }
     } catch (error) {
-        console.error('Image save error:', error);
+        console.error('Image processing error:', error);
     }
 
     // オンラインアップロード（存在すれば実行）
@@ -809,6 +1372,9 @@ async function handleAddAkyo(event) {
 
     // フォームリセット
     event.target.reset();
+    attributeManagerApi.resetField('add');
+    clearDuplicateStatus(document.getElementById('nicknameDuplicateStatus'));
+    clearDuplicateStatus(document.getElementById('avatarDuplicateStatus'));
     const imagePreview = document.getElementById('imagePreview');
     if (imagePreview) {
         imagePreview.classList.add('hidden');
@@ -1100,20 +1666,13 @@ async function syncPendingEditImage(akyoId) {
         return { hasPending: false };
     }
 
-    // まずはローカルストレージ系へ保存
-    imageDataMap[akyoId] = dataUrl;
     try {
-        if (window.saveSingleImage) {
-            await window.saveSingleImage(akyoId, dataUrl);
+        await persistImage(akyoId, dataUrl);
+    } catch (error) {
+        if (error && error.name === 'QuotaExceededError') {
+            throw new Error('ローカル保存に失敗しました: 容量不足です');
         }
-    } catch (e) {
-        throw new Error(`ローカル保存に失敗しました: ${e?.message || e}`);
-    }
-
-    try {
-        localStorage.setItem('akyoImages', JSON.stringify(imageDataMap));
-    } catch (e) {
-        console.debug('Failed to persist pending edit image to localStorage', e);
+        throw new Error(`ローカル保存に失敗しました: ${error?.message || error}`);
     }
 
     const preview = document.getElementById(`editImagePreview-${akyoId}`);
@@ -1159,19 +1718,7 @@ async function syncPendingEditImage(akyoId) {
 async function removeImageForId(akyoId) {
     if (!confirm(`Akyo #${akyoId} の画像を削除しますか？`)) return;
     try {
-        if (window.deleteSingleImage) {
-            await window.deleteSingleImage(akyoId);
-        }
-        delete imageDataMap[akyoId];
-        try {
-            localStorage.setItem('akyoImages', JSON.stringify(imageDataMap));
-        } catch (e) {
-            if (e && e.name === 'QuotaExceededError') {
-                showNotification('容量不足！migrate-storage.htmlでIndexedDBへ移行してください', 'error');
-            } else {
-                console.debug('localStorage persist failed', e);
-            }
-        }
+        const { localBackupWarning } = await removeImagePersistent(akyoId);
         const preview = document.getElementById(`editImagePreview-${akyoId}`);
         if (preview) {
             const id3 = String(akyoId).padStart(3, '0');
@@ -1180,8 +1727,11 @@ async function removeImageForId(akyoId) {
         }
         updateImageGallery();
         showNotification(`Akyo #${akyoId} の画像を削除しました`, 'success');
+        if (localBackupWarning) {
+            showNotification('容量不足！migrate-storage.htmlでIndexedDBへ移行してください', 'error');
+        }
     } catch (e) {
-        showNotification('削除エラー: ' + e.message, 'error');
+        showNotification('削除エラー: ' + (e?.message || e), 'error');
     }
 }
 
@@ -1266,15 +1816,34 @@ function editAkyo(akyoId) {
     const safeDisplayId = escapeHtml(akyo.id);
     const safeNickname = escapeHtml(akyo.nickname || '');
     const safeAvatarName = escapeHtml(akyo.avatarName || '');
-    const safeAttribute = escapeHtml(akyo.attribute || '');
+    const attributeRawValue = akyo.attribute || '';
+    const safeAttribute = escapeHtml(attributeRawValue);
     const safeCreator = escapeHtml(akyo.creator || '');
     const safeAvatarUrl = escapeHtml(akyo.avatarUrl || '');
     const safeNotes = escapeHtml(akyo.notes || '');
     const previewSrc = imageDataMap[akyo.id] || (typeof getAkyoImageUrl === 'function' ? getAkyoImageUrl(id3) : '');
     const safePreviewSrc = escapeHtml(previewSrc || '');
 
+    const nicknameInputId = `editNickname-${safeAkyoId}`;
+    const nicknameStatusId = `nicknameStatus-${safeAkyoId}`;
+    const nicknameCheckButtonId = `nicknameCheck-${safeAkyoId}`;
+    const avatarInputId = `editAvatarName-${safeAkyoId}`;
+    const avatarStatusId = `avatarStatus-${safeAkyoId}`;
+    const avatarCheckButtonId = `avatarCheck-${safeAkyoId}`;
+    const attributeFieldId = `edit-${safeAkyoId}`;
+    const attributeHiddenId = `attributeInput-${safeAkyoId}`;
+    const attributeListId = `attributeList-${safeAkyoId}`;
+    const attributePlaceholderId = `attributePlaceholder-${safeAkyoId}`;
+    const attributeSelections = attributeManagerApi.parseAttributeString(attributeRawValue);
+    const attributeListClass = attributeSelections.length
+        ? 'mt-2 flex flex-wrap gap-2 max-h-32 overflow-y-auto pr-1'
+        : 'hidden mt-2 flex flex-wrap gap-2 max-h-32 overflow-y-auto pr-1';
+    const attributePlaceholderClass = attributeSelections.length
+        ? 'hidden text-sm text-gray-500'
+        : 'text-sm text-gray-500';
+
     content.innerHTML = `
-        <form onsubmit="handleUpdateAkyo(event, '${safeAkyoId}')">
+        <form onsubmit="handleUpdateAkyo(event, '${safeAkyoId}')" data-attribute-field-id="${attributeFieldId}">
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div>
                     <label class="block text-gray-700 text-sm font-medium mb-1">ID（変更不可）</label>
@@ -1283,21 +1852,50 @@ function editAkyo(akyoId) {
                 </div>
 
                 <div>
-                    <label class="block text-gray-700 text-sm font-medium mb-1">通称</label>
-                    <input type="text" name="nickname" value="${safeNickname}"
-                           class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500">
+                    <div class="flex items-center justify-between gap-2">
+                        <label class="block text-gray-700 text-sm font-medium">通称</label>
+                        <button type="button" id="${nicknameCheckButtonId}"
+                                class="inline-flex items-center gap-2 px-3 py-1.5 text-sm border border-orange-200 text-orange-700 bg-orange-50 rounded-lg hover:bg-orange-100 transition-colors">
+                            <i class="fas fa-search"></i>
+                            同じ通称が既に登録されているか確認
+                        </button>
+                    </div>
+                    <input type="text" name="nickname" id="${nicknameInputId}" value="${safeNickname}"
+                           class="mt-2 w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500">
+                    <p id="${nicknameStatusId}" class="mt-2 text-sm hidden" data-status-base-class="mt-2 text-sm" aria-live="polite"></p>
                 </div>
 
                 <div>
                     <label class="block text-gray-700 text-sm font-medium mb-1">アバター名</label>
-                    <input type="text" name="avatarName" value="${safeAvatarName}" required
+                    <input type="text" name="avatarName" id="${avatarInputId}" value="${safeAvatarName}" required
                            class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500">
+                    <div class="mt-2 flex flex-col sm:flex-row sm:items-center gap-2">
+                        <button type="button" id="${avatarCheckButtonId}"
+                                class="inline-flex items-center gap-2 px-3 py-1.5 text-sm border border-orange-200 text-orange-700 bg-orange-50 rounded-lg hover:bg-orange-100 transition-colors">
+                            <i class="fas fa-search"></i>
+                            同じアバター名が既に登録されているか確認
+                        </button>
+                        <p id="${avatarStatusId}" class="text-sm hidden mt-1 sm:mt-0 sm:ml-2" data-status-base-class="text-sm mt-1 sm:mt-0 sm:ml-2" aria-live="polite"></p>
+                    </div>
                 </div>
 
                 <div>
                     <label class="block text-gray-700 text-sm font-medium mb-1">属性</label>
-                    <input type="text" name="attribute" value="${safeAttribute}" required
-                           class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500">
+                    <div class="space-y-2">
+                        <button type="button"
+                                class="w-full flex items-center justify-center gap-2 px-3 py-2 bg-green-100 text-green-800 border border-green-300 rounded-lg hover:bg-green-200 transition-colors"
+                                data-attribute-target="${attributeFieldId}">
+                            <i class="fas fa-tags"></i>
+                            属性を管理
+                        </button>
+                        <input type="hidden" name="attribute" id="${attributeHiddenId}" value="${safeAttribute}">
+                        <div class="border border-dashed border-green-200 rounded-lg bg-white/60 p-3">
+                            <p id="${attributePlaceholderId}" class="${attributePlaceholderClass}">
+                                選択された属性がここに表示されます
+                            </p>
+                            <div id="${attributeListId}" class="${attributeListClass}" role="list"></div>
+                        </div>
+                    </div>
                 </div>
 
                 <div>
@@ -1322,7 +1920,7 @@ function editAkyo(akyoId) {
             <div class="mt-4">
                 <label class="block text-gray-700 text-sm font-medium mb-1">画像</label>
                 <div class="flex items-center gap-3">
-                    <img id="editImagePreview-${safeAkyoId}" src="${safePreviewSrc}" class="w-32 h-24 object-cover rounded border" onerror="this.style.display='none'" />
+                    <img id="editImagePreview-${safeAkyoId}" src="${safePreviewSrc}" alt="Akyo #${safeDisplayId} の画像プレビュー" class="w-32 h-24 object-cover rounded border" onerror="this.style.display='none'" />
                     <input type="file" accept=".webp,.png,.jpg,.jpeg" onchange="handleEditImageSelect(event, '${safeAkyoId}')" class="text-sm" />
                     <button type="button" data-action="remove-edit-image" data-id="${safeAkyoId}" class="px-3 py-2 bg-red-500 text-white rounded hover:bg-red-600 text-sm">画像を削除</button>
                 </div>
@@ -1335,6 +1933,51 @@ function editAkyo(akyoId) {
         </form>
     `;
 
+    const attributeHiddenInput = content.querySelector(`#${attributeHiddenId}`);
+    const attributeBadgeContainer = content.querySelector(`#${attributeListId}`);
+    const attributePlaceholderEl = content.querySelector(`#${attributePlaceholderId}`);
+    const attributeButton = content.querySelector(`[data-attribute-target="${attributeFieldId}"]`);
+    attributeManagerApi.registerField(attributeFieldId, {
+        hiddenInput: attributeHiddenInput,
+        badgeContainer: attributeBadgeContainer,
+        placeholder: attributePlaceholderEl,
+        button: attributeButton,
+    }, { initialValue: attributeRawValue });
+    attributeManagerApi.setCurrentEditField(attributeFieldId);
+    attributeManagerApi.ensureFieldSync(attributeFieldId, attributeRawValue);
+
+    const nicknameCheckButton = content.querySelector(`#${nicknameCheckButtonId}`);
+    const nicknameInputEl = content.querySelector(`#${nicknameInputId}`);
+    const nicknameStatusEl = content.querySelector(`#${nicknameStatusId}`);
+    attachDuplicateChecker({
+        button: nicknameCheckButton,
+        input: nicknameInputEl,
+        status: nicknameStatusEl,
+        field: 'nickname',
+        texts: {
+            empty: '通称を入力してください',
+            success: '重複している通称はありません',
+            duplicatePrefix: '重複している通称が見つかりました: ',
+        },
+        excludeId: akyo.id,
+    });
+
+    const avatarCheckButton = content.querySelector(`#${avatarCheckButtonId}`);
+    const avatarInputEl = content.querySelector(`#${avatarInputId}`);
+    const avatarStatusEl = content.querySelector(`#${avatarStatusId}`);
+    attachDuplicateChecker({
+        button: avatarCheckButton,
+        input: avatarInputEl,
+        status: avatarStatusEl,
+        field: 'avatarName',
+        texts: {
+            empty: 'アバター名を入力してください',
+            success: '重複しているアバター名はありません',
+            duplicatePrefix: '重複しているアバター名が見つかりました: ',
+        },
+        excludeId: akyo.id,
+    });
+
     modal.classList.remove('hidden');
 }
 
@@ -1342,6 +1985,12 @@ function editAkyo(akyoId) {
 // Akyo更新処理
 async function handleUpdateAkyo(event, akyoId) {
     event.preventDefault();
+
+    const fieldId = event.target.getAttribute('data-attribute-field-id');
+    if (fieldId && !attributeManagerApi.hasSelection(fieldId)) {
+        showNotification('属性を1つ以上選択してください', 'error');
+        return;
+    }
 
     const formData = new FormData(event.target);
     const akyoIndex = akyoData.findIndex(a => a.id === akyoId);
@@ -1352,7 +2001,7 @@ async function handleUpdateAkyo(event, akyoId) {
         ...akyoData[akyoIndex],
         nickname: formData.get('nickname'),
         avatarName: formData.get('avatarName'),
-        attribute: formData.get('attribute'),
+        attribute: attributeManagerApi.serializeAttributes(formData.get('attribute')),
         notes: formData.get('notes'),
         creator: formData.get('creator'),
         avatarUrl: formData.get('avatarUrl')
@@ -1360,6 +2009,7 @@ async function handleUpdateAkyo(event, akyoId) {
 
     try {
         await updateCSVFile();
+        refreshDerivedCollections();
     } catch (e) {
         console.error('updateCSVFile failed', e);
         showNotification('更新内容の保存に失敗しました', 'error');
@@ -1469,6 +2119,7 @@ async function deleteAkyo(akyoId) {
     localStorage.setItem('akyoFavorites', JSON.stringify(favorites));
 
     await updateCSVFile();
+    refreshDerivedCollections();
 
     showNotification(`Akyo #${akyoId} を削除し、後続のIDを詰めました`, 'success');
     updateEditList();
@@ -1483,6 +2134,7 @@ window.deleteAkyo = deleteAkyo;
 
 // 編集モーダルを閉じる
 function closeEditModal() {
+    attributeManagerApi.clearCurrentEditField();
     document.getElementById('editModal').classList.add('hidden');
 }
 
@@ -1491,26 +2143,18 @@ window.closeEditModal = closeEditModal;
 
 // CSV更新
 async function updateCSVFile() {
-    // CSVフォーマットに変換
-    const escapeCsv = (val) => {
-        const s = (val ?? '').toString();
-        const needsQuote = /[",\n]/.test(s);
-        const body = s.replace(/"/g, '""');
-        return needsQuote ? `"${body}"` : body;
-    };
-
     let csvContent = 'ID,見た目,通称,アバター名,属性（モチーフが基準）,備考,作者（敬称略）,アバターURL\n';
 
     akyoData.forEach(akyo => {
         const row = [
-            escapeCsv(akyo.id),
-            escapeCsv(akyo.appearance),
-            escapeCsv(akyo.nickname),
-            escapeCsv(akyo.avatarName),
-            escapeCsv(akyo.attribute),
-            escapeCsv(akyo.notes),
-            escapeCsv(akyo.creator),
-            escapeCsv(akyo.avatarUrl)
+            escapeCsvValue(akyo.id),
+            escapeCsvValue(akyo.appearance),
+            escapeCsvValue(akyo.nickname),
+            escapeCsvValue(akyo.avatarName),
+            escapeCsvValue(akyo.attribute),
+            escapeCsvValue(akyo.notes),
+            escapeCsvValue(akyo.creator),
+            escapeCsvValue(akyo.avatarUrl)
         ].join(',');
         csvContent += row + '\n';
     });
@@ -1543,7 +2187,8 @@ async function updateCSVFile() {
                         detail = await res.text();
                     }
                 } catch(_) {}
-                const msg = `GitHubへの反映に失敗しました (${res.status}) ${detail ? String(detail).slice(0, 200) : ''}`.trim();
+                const extra = detail ? ` ${String(detail).slice(0, 200)}` : '';
+                const msg = `GitHubへの反映に失敗しました (${res.status})${extra}。ローカル保存は完了しています。後で再度同期をお試しください。`;
                 console.error('commit-csv failed', res.status, detail || json);
                 showNotification(msg, 'error');
             } else {
@@ -1559,7 +2204,8 @@ async function updateCSVFile() {
     } catch (e) {
         console.error('commit-csv request error', e);
         const detail = (e && (e.message || e.toString && e.toString())) || '';
-        const msg = `GitHubへの反映通信でエラーが発生しました ${detail ? `- ${String(detail).slice(0, 200)}` : ''}`.trim();
+        const suffix = detail ? ` (${String(detail).slice(0, 200)})` : '';
+        const msg = `GitHubへの反映通信でエラーが発生しました${suffix}。ローカル保存は完了しています。ネットワークを確認のうえ再試行してください。`;
         showNotification(msg, 'error');
     }
 
@@ -1679,6 +2325,7 @@ async function uploadCSV() {
     akyoData = [...akyoData, ...window.pendingCSVData].sort((a, b) => a.id.localeCompare(b.id));
 
     await updateCSVFile();
+    refreshDerivedCollections();
     try {
         const ver = parseInt(localStorage.getItem('akyoDataVersion') || '0', 10) + 1;
         localStorage.setItem('akyoDataVersion', String(ver));
@@ -1748,9 +2395,11 @@ function handleBulkImages(files) {
             const safeSuggestedId = escapeHtml(suggestedId);
             const safeFileName = escapeHtml(currentFile.name || '');
             const safeUniqueId = escapeHtml(uniqueId);
+            const previewAltText = currentFile.name ? `プレビュー: ${currentFile.name}` : '画像プレビュー';
+            const safePreviewAlt = escapeHtml(previewAltText);
 
             div.innerHTML = `
-                <img src="${safeImageData}" class="w-12 h-12 object-cover rounded">
+                <img src="${safeImageData}" alt="${safePreviewAlt}" class="w-12 h-12 object-cover rounded">
                 <input type="text" placeholder="AkyoID" value="${safeSuggestedId}"
                        class="px-2 py-1 border rounded w-20 mapping-id-input"
                        inputmode="numeric" pattern="\\d{3}" maxlength="3"
@@ -1842,26 +2491,7 @@ async function saveImageMapping(inputId) {
     }
 
     try {
-        // ストレージアダプターを使用して保存（IndexedDB優先）
-        if (!imageDataMap) imageDataMap = {};
-        if (window.saveSingleImage) {
-            await window.saveSingleImage(akyoId, imageData);
-            imageDataMap[akyoId] = imageData;
-            try { localStorage.setItem('akyoImages', JSON.stringify(imageDataMap)); } catch (_) {}
-        } else {
-            // フォールバック: 従来のLocalStorage保存
-            imageDataMap[akyoId] = imageData;
-            try {
-                localStorage.setItem('akyoImages', JSON.stringify(imageDataMap));
-            } catch (e) {
-                if (e && e.name === 'QuotaExceededError') {
-                    delete imageDataMap[akyoId];
-                    showNotification('容量不足！migrate-storage.htmlでIndexedDBへ移行してください', 'error');
-                    return;
-                }
-                throw e;
-            }
-        }
+        await persistImage(akyoId, imageData);
 
         console.debug(`Image saved for ID ${akyoId}`);
 
@@ -1878,10 +2508,10 @@ async function saveImageMapping(inputId) {
 
     } catch (error) {
         console.error('Save error:', error);
-        if (error.name === 'QuotaExceededError') {
+        if (error && error.name === 'QuotaExceededError') {
             showNotification('容量不足！migrate-storage.htmlでIndexedDBへ移行してください', 'error');
         } else {
-            showNotification('保存エラー: ' + error.message, 'error');
+            showNotification('保存エラー: ' + (error?.message || error), 'error');
         }
     }
 }
@@ -2024,16 +2654,8 @@ async function saveAllMappings() {
             continue;
         }
 
-        // ストレージアダプターを使用して保存
         try {
-            if (window.saveSingleImage) {
-                await window.saveSingleImage(akyoId, imageData);
-                imageDataMap[akyoId] = imageData;
-                try { localStorage.setItem('akyoImages', JSON.stringify(imageDataMap)); } catch (_) {}
-            } else {
-                // フォールバック
-                imageDataMap[akyoId] = imageData;
-            }
+            await persistImage(akyoId, imageData);
             savedCount++;
             console.debug(`保存: ${akyoId}`);
 
@@ -2045,20 +2667,12 @@ async function saveAllMappings() {
             }
         } catch (error) {
             errorCount++;
-            console.error(`保存エラー ${akyoId}:`, error);
-        }
-    }
-
-    // フォールバック: LocalStorageに一括保存（アダプターがない場合）
-    if (!window.saveSingleImage && savedCount > 0) {
-        try {
-            localStorage.setItem('akyoImages', JSON.stringify(imageDataMap));
-            console.debug(`LocalStorageに保存: ${savedCount}件`);
-        } catch (error) {
-            if (error.name === 'QuotaExceededError') {
+            if (error && error.name === 'QuotaExceededError') {
                 showNotification('容量不足！migrate-storage.htmlでIndexedDBへ移行してください', 'error');
                 return;
             }
+            console.error(`保存エラー ${akyoId}:`, error);
+            showNotification(`保存エラー: ${akyoId} - ${error?.message || error}`, 'error');
         }
     }
 
@@ -2130,9 +2744,13 @@ function updateImageGallery() {
         const safeAkyoId = escapeHtml(akyoId);
         const safeImageData = escapeHtml(imageData || '');
         const safeLabel = escapeHtml(akyo ? (akyo.nickname || akyo.avatarName || '') : '未登録');
+        const altLabel = akyo && (akyo.nickname || akyo.avatarName)
+            ? `Akyo #${akyoId} ${akyo.nickname || akyo.avatarName}`
+            : `Akyo #${akyoId} の画像`;
+        const safeAlt = escapeHtml(altLabel.trim());
 
         div.innerHTML = `
-            <img src="${safeImageData}" class="w-full h-24 object-cover rounded-lg">
+            <img src="${safeImageData}" alt="${safeAlt}" class="w-full h-24 object-cover rounded-lg">
             <div class="absolute inset-0 bg-black bg-opacity-50 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity rounded-lg flex items-center justify-center">
                 <div class="text-white text-center">
                     <div class="font-bold">#${safeAkyoId}</div>
@@ -2155,13 +2773,12 @@ function updateImageGallery() {
 async function removeImage(akyoId) {
     if (!confirm(`Akyo #${akyoId} の画像を削除しますか？`)) return;
     try {
-        if (window.deleteSingleImage) {
-            await window.deleteSingleImage(akyoId);
-        }
-        delete imageDataMap[akyoId];
-        try { localStorage.setItem('akyoImages', JSON.stringify(imageDataMap)); } catch (_) {}
+        const { localBackupWarning } = await removeImagePersistent(akyoId);
         updateImageGallery();
         showNotification(`Akyo #${akyoId} の画像を削除しました`, 'success');
+        if (localBackupWarning) {
+            showNotification('容量不足！migrate-storage.htmlでIndexedDBへ移行してください', 'error');
+        }
     } catch (e) {
         showNotification('削除エラー: ' + (e?.message || e), 'error');
     }
@@ -2342,6 +2959,7 @@ async function renumberAllIds() {
     localStorage.setItem('akyoFavorites', JSON.stringify(favorites));
 
     await updateCSVFile();
+    refreshDerivedCollections();
 
     showNotification('すべてのIDを再採番しました', 'success');
     updateEditList();
@@ -2354,24 +2972,19 @@ window.renumberAllIds = renumberAllIds;
 
 // CSVエクスポート機能
 function exportCSV() {
-    const csvEscape = (value) => {
-        const str = value === null || value === undefined ? '' : String(value);
-        return /[",\n]/.test(str) ? `"${str.replace(/"/g, '""')}"` : str;
-    };
-
     // CSVフォーマットに変換
     let csvContent = 'ID,見た目,通称,アバター名,属性（モチーフが基準）,備考,作者（敬称略）,アバターURL\n';
 
     akyoData.forEach(akyo => {
         const row = [
-            csvEscape(akyo.id),
-            csvEscape(akyo.appearance),
-            csvEscape(akyo.nickname),
-            csvEscape(akyo.avatarName),
-            csvEscape(akyo.attribute),
-            csvEscape(akyo.notes),
-            csvEscape(akyo.creator),
-            csvEscape(akyo.avatarUrl)
+            escapeCsvValue(akyo.id),
+            escapeCsvValue(akyo.appearance),
+            escapeCsvValue(akyo.nickname),
+            escapeCsvValue(akyo.avatarName),
+            escapeCsvValue(akyo.attribute),
+            escapeCsvValue(akyo.notes),
+            escapeCsvValue(akyo.creator),
+            escapeCsvValue(akyo.avatarUrl)
         ].join(',');
         csvContent += row + '\n';
     });

--- a/js/attribute-manager.js
+++ b/js/attribute-manager.js
@@ -1,0 +1,839 @@
+(function (global) {
+    'use strict';
+
+    const defaultDependencies = {
+        notify: (message, type = 'info', options) => {
+            if (message) {
+                const level = type === 'error' ? 'error' : type === 'warning' ? 'warn' : 'info';
+                console[level](`[attributeManager] ${message}`);
+            }
+        },
+        confirmDelete: () => true,
+        getCurrentRole: () => null,
+        canDelete: (meta, role) => role === 'owner' || (meta ? !!meta.isSession : false),
+        onDelete: async () => true,
+        onAttributesChanged: () => {},
+        buildDeleteMessage: ({ name }) => `属性「${name}」を削除しますか？\n\n※ この属性を持つAkyoからも削除されます`,
+    };
+
+    const nameCollator = typeof Intl !== 'undefined' && Intl.Collator
+        ? new Intl.Collator('ja')
+        : null;
+
+    const toLocaleLower = (value) => {
+        return typeof value === 'string' ? value.toLocaleLowerCase('ja') : '';
+    };
+
+    function createAttributeManagerInstance() {
+        const FALLBACK_ATTRIBUTE_NAME = '未分類';
+        const ATTRIBUTE_DELIMITER = ',';
+
+        const dependencies = { ...defaultDependencies };
+
+        const state = {
+            attributes: new Map([
+                [
+                    FALLBACK_ATTRIBUTE_NAME,
+                    { name: FALLBACK_ATTRIBUTE_NAME, isSession: false, searchKey: toLocaleLower(FALLBACK_ATTRIBUTE_NAME) },
+                ],
+            ]),
+            fields: new Map(),
+            modalSelection: [],
+            activeFieldId: null,
+            searchQuery: '',
+            isInitialized: false,
+            lastTriggerButton: null,
+            dom: {
+                modal: null,
+                overlay: null,
+                closeButtons: [],
+                searchInput: null,
+                grid: null,
+                emptyMessage: null,
+                applyButton: null,
+                createStart: null,
+                createForm: null,
+                createInput: null,
+                createConfirm: null,
+                createCancel: null,
+                scrollRegion: null,
+            },
+            currentEditFieldId: null,
+            sortedCache: [],
+            isCacheDirty: true,
+            optionRefs: new Map(),
+        };
+
+        const createMeta = (name, props = {}) => ({
+            ...props,
+            name,
+            searchKey: toLocaleLower(name),
+        });
+
+        const markAttributesDirty = () => {
+            state.isCacheDirty = true;
+        };
+
+        const getSortedAttributes = () => {
+            if (!state.isCacheDirty) {
+                return state.sortedCache;
+            }
+            const entries = Array.from(state.attributes.values());
+            if (nameCollator) {
+                entries.sort((a, b) => nameCollator.compare(a.name, b.name));
+            } else {
+                entries.sort((a, b) => a.name.localeCompare(b.name, 'ja'));
+            }
+            state.sortedCache = entries;
+            state.isCacheDirty = false;
+            return state.sortedCache;
+        };
+
+        const normalizeName = (name) => (typeof name === 'string' ? name.replace(/\s+/g, ' ').trim() : '');
+
+        const tokenizeAttributes = (value) => {
+            if (Array.isArray(value)) {
+                return value;
+            }
+            if (value === null || value === undefined) {
+                return [];
+            }
+            if (typeof value === 'string') {
+                return value.split(ATTRIBUTE_DELIMITER);
+            }
+            return String(value).split(ATTRIBUTE_DELIMITER);
+        };
+
+        const normalizeAttributeTokens = (tokens) => {
+            const seen = new Set();
+            const normalized = [];
+            tokens.forEach((token) => {
+                const normalizedName = normalizeName(token);
+                if (!normalizedName || seen.has(normalizedName)) {
+                    return;
+                }
+                seen.add(normalizedName);
+                normalized.push(normalizedName);
+            });
+            return normalized;
+        };
+
+        const parseAttributeString = (value) => {
+            return normalizeAttributeTokens(tokenizeAttributes(value));
+        };
+
+        const serializeAttributes = (value) => {
+            return normalizeAttributeTokens(tokenizeAttributes(value)).join(ATTRIBUTE_DELIMITER);
+        };
+
+        const getFallbackAttributeName = () => {
+            return state.attributes.has(FALLBACK_ATTRIBUTE_NAME) ? FALLBACK_ATTRIBUTE_NAME : null;
+        };
+
+        const ensureFallbackSelection = (selection) => {
+            if (!Array.isArray(selection)) {
+                return false;
+            }
+
+            const fallbackName = getFallbackAttributeName();
+            if (!fallbackName) {
+                return false;
+            }
+
+            const fallbackIndex = selection.indexOf(fallbackName);
+
+            if (selection.length === 0) {
+                selection.push(fallbackName);
+                return true;
+            }
+
+            if (fallbackIndex !== -1 && selection.length > 1) {
+                selection.splice(fallbackIndex, 1);
+                return true;
+            }
+
+            return false;
+        };
+
+        const addToOrderedSelection = (selection, value) => {
+            if (!selection.includes(value)) {
+                selection.push(value);
+            }
+        };
+
+        const removeFromOrderedSelection = (selection, value) => {
+            const index = selection.indexOf(value);
+            if (index !== -1) {
+                selection.splice(index, 1);
+            }
+        };
+
+        function configure(overrides = {}) {
+            if (!overrides || typeof overrides !== 'object') {
+                return api;
+            }
+
+            if (typeof overrides.notify === 'function') {
+                dependencies.notify = overrides.notify;
+            }
+            if (typeof overrides.confirmDelete === 'function') {
+                dependencies.confirmDelete = overrides.confirmDelete;
+            }
+            if (typeof overrides.getCurrentRole === 'function') {
+                dependencies.getCurrentRole = overrides.getCurrentRole;
+            }
+            if (typeof overrides.canDelete === 'function') {
+                dependencies.canDelete = overrides.canDelete;
+            }
+            if (typeof overrides.onDelete === 'function') {
+                dependencies.onDelete = overrides.onDelete;
+            }
+            if (typeof overrides.onAttributesChanged === 'function') {
+                dependencies.onAttributesChanged = overrides.onAttributesChanged;
+            }
+            if (typeof overrides.buildDeleteMessage === 'function') {
+                dependencies.buildDeleteMessage = overrides.buildDeleteMessage;
+            }
+
+            return api;
+        }
+
+        function registerBaseField() {
+            const hiddenInput = document.getElementById('addAttributeInput');
+            const badgeContainer = document.getElementById('addAttributeList');
+            const placeholder = document.getElementById('addAttributePlaceholder');
+            const button = document.querySelector('[data-attribute-target="add"]');
+            if (hiddenInput && badgeContainer && placeholder && button) {
+                registerField('add', { hiddenInput, badgeContainer, placeholder, button }, { initialValue: hiddenInput.value });
+            }
+        }
+
+        function ensureDomReferences() {
+            if (state.isInitialized) {
+                return true;
+            }
+
+            const modal = document.getElementById('attributeModal');
+            if (!modal) {
+                console.warn('[attributeManager] attributeModal not found; attribute features disabled');
+                return false;
+            }
+
+            state.dom.modal = modal;
+            state.dom.modal.setAttribute('aria-hidden', 'true');
+            state.dom.overlay = modal.querySelector('[data-attribute-overlay]');
+            state.dom.closeButtons = Array.from(modal.querySelectorAll('[data-attribute-close]'));
+            state.dom.searchInput = document.getElementById('attributeSearchInput');
+            state.dom.grid = document.getElementById('attributeListGrid');
+            state.dom.emptyMessage = document.getElementById('attributeEmptyMessage');
+            state.dom.applyButton = document.getElementById('attributeApplyButton');
+            state.dom.createStart = document.getElementById('attributeCreateStart');
+            state.dom.createForm = document.getElementById('attributeCreateForm');
+            state.dom.createInput = document.getElementById('attributeNewInput');
+            state.dom.createConfirm = document.getElementById('attributeCreateConfirm');
+            state.dom.createCancel = document.getElementById('attributeCreateCancel');
+            state.dom.scrollRegion = document.getElementById('attributeListScroll');
+
+            return true;
+        }
+
+        function bindModalEvents() {
+            if (!ensureDomReferences()) {
+                return;
+            }
+
+            if (state.dom.overlay) {
+                state.dom.overlay.addEventListener('click', closeModal);
+            }
+            state.dom.closeButtons.forEach((button) => {
+                button.addEventListener('click', closeModal);
+            });
+            if (state.dom.applyButton) {
+                state.dom.applyButton.addEventListener('click', applySelection);
+            }
+            if (state.dom.searchInput) {
+                state.dom.searchInput.addEventListener('input', handleSearchInput);
+            }
+            if (state.dom.createStart) {
+                state.dom.createStart.addEventListener('click', () => toggleCreateForm(true));
+            }
+            if (state.dom.createCancel) {
+                state.dom.createCancel.addEventListener('click', () => toggleCreateForm(false));
+            }
+            if (state.dom.createConfirm) {
+                state.dom.createConfirm.addEventListener('click', confirmCreateAttribute);
+            }
+            if (state.dom.createInput) {
+                state.dom.createInput.addEventListener('keydown', (event) => {
+                    if (event.key === 'Enter') {
+                        event.preventDefault();
+                        confirmCreateAttribute();
+                    }
+                });
+            }
+            if (state.dom.grid) {
+                state.dom.grid.addEventListener('click', handleGridClick);
+            }
+
+            state.isInitialized = true;
+        }
+
+        function init() {
+            if (!ensureDomReferences()) {
+                return;
+            }
+
+            if (!state.isInitialized) {
+                bindModalEvents();
+            }
+
+            registerBaseField();
+        }
+
+        function registerField(fieldId, elements, { initialValue } = {}) {
+            if (!elements || !elements.hiddenInput || !elements.badgeContainer || !elements.placeholder) {
+                return;
+            }
+
+            const id = String(fieldId);
+            unregisterField(id);
+
+            const field = {
+                id,
+                hiddenInput: elements.hiddenInput,
+                badgeContainer: elements.badgeContainer,
+                placeholder: elements.placeholder,
+                button: elements.button || null,
+                buttonHandler: null,
+                selected: [],
+            };
+
+            const initial = initialValue !== undefined ? initialValue : elements.hiddenInput.value;
+            field.selected = parseAttributeString(initial);
+            ensureFallbackSelection(field.selected);
+
+            if (field.button) {
+                field.buttonHandler = () => openModal(id);
+                field.button.addEventListener('click', field.buttonHandler);
+            }
+
+            state.fields.set(id, field);
+            syncFieldValue(id);
+        }
+
+        function unregisterField(fieldId) {
+            const field = state.fields.get(fieldId);
+            if (!field) return;
+
+            if (field.button && field.buttonHandler) {
+                field.button.removeEventListener('click', field.buttonHandler);
+            }
+
+            state.fields.delete(fieldId);
+            if (state.currentEditFieldId === fieldId) {
+                state.currentEditFieldId = null;
+            }
+        }
+
+        function openModal(fieldId) {
+            if (!state.isInitialized || !state.dom.modal) return;
+            const field = state.fields.get(fieldId);
+            if (!field) return;
+
+            state.activeFieldId = fieldId;
+            state.modalSelection = field.selected.slice();
+            ensureFallbackSelection(state.modalSelection);
+            state.searchQuery = '';
+            state.lastTriggerButton = field.button || null;
+
+            if (state.dom.searchInput) {
+                state.dom.searchInput.value = '';
+            }
+
+            toggleCreateForm(false);
+            renderModalList();
+            state.dom.modal.classList.remove('hidden');
+            state.dom.modal.setAttribute('aria-hidden', 'false');
+            setTimeout(() => {
+                if (state.dom.searchInput) {
+                    state.dom.searchInput.focus();
+                }
+            }, 0);
+        }
+
+        function closeModal() {
+            if (!state.dom.modal) return;
+            state.dom.modal.classList.add('hidden');
+            state.dom.modal.setAttribute('aria-hidden', 'true');
+            state.activeFieldId = null;
+            state.modalSelection = [];
+            state.searchQuery = '';
+            if (state.dom.searchInput) {
+                state.dom.searchInput.value = '';
+            }
+            toggleCreateForm(false);
+            if (state.lastTriggerButton) {
+                const button = state.lastTriggerButton;
+                state.lastTriggerButton = null;
+                setTimeout(() => {
+                    if (typeof button.focus === 'function') {
+                        button.focus();
+                    }
+                }, 0);
+            }
+        }
+
+        function handleSearchInput(event) {
+            state.searchQuery = normalizeName(event.target.value || '');
+            renderModalList();
+        }
+
+        function toggleCreateForm(show) {
+            const form = state.dom.createForm;
+            const startButton = state.dom.createStart;
+            if (!form || !startButton) return;
+
+            const expandedValue = show ? 'true' : 'false';
+            startButton.setAttribute('aria-expanded', expandedValue);
+            form.setAttribute('aria-hidden', show ? 'false' : 'true');
+
+            if (show) {
+                form.classList.remove('hidden');
+                startButton.classList.add('hidden');
+                if (state.dom.createInput) {
+                    state.dom.createInput.value = '';
+                    setTimeout(() => state.dom.createInput.focus(), 0);
+                }
+            } else {
+                form.classList.add('hidden');
+                startButton.classList.remove('hidden');
+                if (state.dom.createInput) {
+                    state.dom.createInput.value = '';
+                }
+            }
+        }
+
+        function confirmCreateAttribute() {
+            if (!state.dom.createInput) return;
+            const value = normalizeName(state.dom.createInput.value);
+            if (!value) {
+                dependencies.notify('属性名を入力してください', 'warning');
+                return;
+            }
+            if (state.attributes.has(value)) {
+                dependencies.notify(`属性「${value}」は既に存在します`, 'warning');
+                state.dom.createInput.value = '';
+                return;
+            }
+
+            state.attributes.set(value, createMeta(value, { isSession: true }));
+            markAttributesDirty();
+            addToOrderedSelection(state.modalSelection, value);
+            ensureFallbackSelection(state.modalSelection);
+            toggleCreateForm(false);
+            renderModalList();
+            dependencies.onAttributesChanged(Array.from(state.attributes.keys()));
+            dependencies.notify(`属性「${value}」を追加しました`, 'success');
+        }
+
+        function handleGridClick(event) {
+            const actionEl = event.target.closest('[data-attribute-action]');
+            if (!actionEl) return;
+
+            const { attributeName: rawName, attributeAction: action } = actionEl.dataset;
+            if (!rawName) return;
+
+            if (action === 'toggle') {
+                toggleSelection(rawName, undefined, actionEl);
+                return;
+            }
+
+            if (action === 'delete') {
+                event.preventDefault();
+                event.stopPropagation();
+                void requestDeleteAttribute(rawName);
+            }
+        }
+
+        function renderModalList() {
+            if (!state.dom.grid) return;
+            const scrollRegion = state.dom.scrollRegion;
+            const scrollTop = scrollRegion ? scrollRegion.scrollTop : 0;
+
+            const query = state.searchQuery ? toLocaleLower(state.searchQuery) : '';
+            const baseList = getSortedAttributes();
+            const items = query
+                ? baseList.filter(meta => meta.searchKey.includes(query))
+                : baseList;
+
+            if (state.dom.emptyMessage) {
+                if (items.length === 0) {
+                    state.dom.emptyMessage.classList.remove('hidden');
+                } else {
+                    state.dom.emptyMessage.classList.add('hidden');
+                }
+            }
+
+            const fragment = document.createDocumentFragment();
+            const selectionSet = new Set(state.modalSelection);
+            state.dom.grid.textContent = '';
+            state.optionRefs = new Map();
+
+            items.forEach((meta) => {
+                const isSelected = selectionSet.has(meta.name);
+                const row = document.createElement('div');
+                row.className = 'flex items-center gap-2';
+
+                const toggleBtn = document.createElement('button');
+                toggleBtn.type = 'button';
+                toggleBtn.dataset.attributeAction = 'toggle';
+                toggleBtn.dataset.attributeName = meta.name;
+                toggleBtn.className = `attribute-option flex-1 flex items-center justify-between gap-3 px-3 py-2 rounded-xl transition-colors ${isSelected ? 'attribute-option--active' : 'attribute-option--inactive'}`;
+                toggleBtn.setAttribute('aria-pressed', isSelected ? 'true' : 'false');
+
+                const left = document.createElement('span');
+                left.className = 'flex items-center gap-3';
+
+                const indicator = document.createElement('span');
+                indicator.className = `attribute-option__indicator flex items-center justify-center w-6 h-6 rounded-full ${isSelected ? 'attribute-option__indicator--active' : 'attribute-option__indicator--inactive'}`;
+                indicator.innerHTML = '<i class="fas fa-check text-xs"></i>';
+
+                const text = document.createElement('span');
+                text.className = 'text-sm font-medium text-gray-800';
+                text.textContent = meta.name;
+
+                left.appendChild(indicator);
+                left.appendChild(text);
+
+                if (meta.isSession) {
+                    const chip = document.createElement('span');
+                    chip.className = 'attribute-chip attribute-chip--session';
+                    chip.textContent = '新規';
+                    left.appendChild(chip);
+                }
+
+                toggleBtn.appendChild(left);
+                row.appendChild(toggleBtn);
+                state.optionRefs.set(meta.name, toggleBtn);
+
+                const canDelete = dependencies.canDelete(meta, dependencies.getCurrentRole());
+                if (canDelete) {
+                    const deleteBtn = document.createElement('button');
+                    deleteBtn.type = 'button';
+                    deleteBtn.dataset.attributeAction = 'delete';
+                    deleteBtn.dataset.attributeName = meta.name;
+                    deleteBtn.className = 'text-sm text-gray-400 hover:text-red-500 transition-colors';
+                    deleteBtn.innerHTML = '<i class="fas fa-trash"></i>';
+                    row.appendChild(deleteBtn);
+                } else {
+                    const spacer = document.createElement('span');
+                    spacer.className = 'w-4 h-4';
+                    row.appendChild(spacer);
+                }
+
+                fragment.appendChild(row);
+            });
+
+            state.dom.grid.appendChild(fragment);
+
+            if (scrollRegion) {
+                scrollRegion.scrollTop = scrollTop;
+            }
+        }
+
+        function toggleSelection(name, forceState, sourceElement) {
+            const normalized = normalizeName(name);
+            if (!normalized) return;
+
+            const currentlySelected = state.modalSelection.includes(normalized);
+            const shouldSelect = typeof forceState === 'boolean' ? forceState : !currentlySelected;
+            const fallbackName = getFallbackAttributeName();
+            const fallbackWasSelected = fallbackName ? state.modalSelection.includes(fallbackName) : false;
+
+            if (shouldSelect && !currentlySelected) {
+                addToOrderedSelection(state.modalSelection, normalized);
+            } else if (!shouldSelect && currentlySelected) {
+                removeFromOrderedSelection(state.modalSelection, normalized);
+            }
+
+            ensureFallbackSelection(state.modalSelection);
+
+            updateModalOptionState(normalized, sourceElement);
+
+            if (fallbackName) {
+                const fallbackIsSelected = state.modalSelection.includes(fallbackName);
+                if (fallbackWasSelected !== fallbackIsSelected || normalized === fallbackName) {
+                    updateModalOptionState(fallbackName);
+                }
+            }
+        }
+
+        function applySelection() {
+            if (!state.activeFieldId) {
+                closeModal();
+                return;
+            }
+
+            const field = state.fields.get(state.activeFieldId);
+            if (!field) {
+                closeModal();
+                return;
+            }
+
+            ensureFallbackSelection(state.modalSelection);
+            field.selected = state.modalSelection.slice();
+            syncFieldValue(state.activeFieldId);
+            closeModal();
+        }
+
+        async function requestDeleteAttribute(name) {
+            const normalized = normalizeName(name);
+            if (!normalized) return;
+
+            const meta = state.attributes.get(normalized);
+            if (!meta) return;
+
+            const role = dependencies.getCurrentRole();
+            const canDelete = dependencies.canDelete(meta, role);
+            if (!canDelete) {
+                dependencies.notify('この属性を削除する権限がありません', 'error');
+                return;
+            }
+
+            const confirmationMessage = dependencies.buildDeleteMessage({ name: normalized, meta, role });
+            if (confirmationMessage && dependencies.confirmDelete(confirmationMessage, { name: normalized, meta, role }) === false) {
+                return;
+            }
+
+            let deleteResult;
+            try {
+                deleteResult = await dependencies.onDelete({ name: normalized, meta, role });
+            } catch (error) {
+                console.error('[attributeManager] onDelete callback failed', error);
+                dependencies.notify('属性の削除処理でエラーが発生しました', 'error');
+                return;
+            }
+
+            if (deleteResult === false) {
+                return;
+            }
+
+            if (state.attributes.delete(normalized)) {
+                markAttributesDirty();
+            }
+            removeFromOrderedSelection(state.modalSelection, normalized);
+            ensureFallbackSelection(state.modalSelection);
+            removeAttributeFromFields(normalized);
+            renderModalList();
+            dependencies.onAttributesChanged(Array.from(state.attributes.keys()));
+
+            if (deleteResult && typeof deleteResult === 'object' && deleteResult.message) {
+                dependencies.notify(deleteResult.message, deleteResult.type || 'success');
+            } else {
+                dependencies.notify(`属性「${normalized}」を削除しました`, 'success');
+            }
+        }
+
+        function removeAttributeFromFields(name) {
+            state.fields.forEach((field) => {
+                if (field.selected.includes(name)) {
+                    field.selected = field.selected.filter(attr => attr !== name);
+                    ensureFallbackSelection(field.selected);
+                    syncFieldValue(field.id);
+                }
+            });
+        }
+
+        function syncFieldValue(fieldId) {
+            const field = state.fields.get(fieldId);
+            if (!field) return;
+
+            const value = serializeAttributes(field.selected);
+            field.hiddenInput.value = value;
+
+            if (field.placeholder) {
+                if (field.selected.length === 0) {
+                    field.placeholder.classList.remove('hidden');
+                } else {
+                    field.placeholder.classList.add('hidden');
+                }
+            }
+
+            if (field.badgeContainer) {
+                field.badgeContainer.textContent = '';
+                if (field.selected.length === 0) {
+                    field.badgeContainer.classList.add('hidden');
+                } else {
+                    field.badgeContainer.classList.remove('hidden');
+                    const fragment = document.createDocumentFragment();
+                    field.selected.forEach((attr) => {
+                        const badge = document.createElement('span');
+                        badge.className = 'attribute-badge inline-flex items-center gap-1 text-xs font-semibold shadow-sm';
+                        badge.textContent = attr;
+                        fragment.appendChild(badge);
+                    });
+                    field.badgeContainer.appendChild(fragment);
+                }
+            }
+        }
+
+        function rebuildFromAkyoData(list) {
+            if (!Array.isArray(list)) return;
+
+            const seen = new Set();
+            list.forEach((akyo) => {
+                parseAttributeString(akyo?.attribute).forEach((attr) => {
+                    seen.add(attr);
+
+                    const existingMeta = state.attributes.get(attr);
+                    if (existingMeta) {
+                        if (existingMeta.isSession) {
+                            const updatedMeta = createMeta(attr, { ...existingMeta, isSession: false });
+                            state.attributes.set(attr, updatedMeta);
+                            markAttributesDirty();
+                        }
+                    } else {
+                        state.attributes.set(attr, createMeta(attr, { isSession: false }));
+                        markAttributesDirty();
+                    }
+                });
+            });
+
+            Array.from(state.attributes.entries()).forEach(([name, meta]) => {
+                if (!meta) return;
+                const shouldKeep = meta.isSession || seen.has(name) || name === FALLBACK_ATTRIBUTE_NAME;
+                if (!shouldKeep) {
+                    if (state.attributes.delete(name)) {
+                        markAttributesDirty();
+                    }
+                    removeAttributeFromFields(name);
+                }
+            });
+
+            if (!state.attributes.has(FALLBACK_ATTRIBUTE_NAME)) {
+                state.attributes.set(
+                    FALLBACK_ATTRIBUTE_NAME,
+                    createMeta(FALLBACK_ATTRIBUTE_NAME, { isSession: false })
+                );
+                markAttributesDirty();
+            } else {
+                const fallbackMeta = state.attributes.get(FALLBACK_ATTRIBUTE_NAME);
+                if (fallbackMeta && fallbackMeta.isSession) {
+                    state.attributes.set(
+                        FALLBACK_ATTRIBUTE_NAME,
+                        createMeta(FALLBACK_ATTRIBUTE_NAME, { ...fallbackMeta, isSession: false })
+                    );
+                    markAttributesDirty();
+                }
+            }
+
+            if (state.activeFieldId) {
+                renderModalList();
+            }
+
+            dependencies.onAttributesChanged(Array.from(state.attributes.keys()));
+        }
+
+        function resetField(fieldId) {
+            const field = state.fields.get(fieldId);
+            if (!field) return;
+            field.selected = [];
+            ensureFallbackSelection(field.selected);
+            syncFieldValue(fieldId);
+        }
+
+        function hasSelection(fieldId) {
+            const field = state.fields.get(fieldId);
+            return !!(field && field.selected.length > 0);
+        }
+
+        function getValue(fieldId) {
+            const field = state.fields.get(fieldId);
+            return field ? serializeAttributes(field.selected) : '';
+        }
+
+        function setCurrentEditField(fieldId) {
+            state.currentEditFieldId = fieldId;
+        }
+
+        function clearCurrentEditField() {
+            if (state.currentEditFieldId) {
+                unregisterField(state.currentEditFieldId);
+                state.currentEditFieldId = null;
+            }
+        }
+
+        function ensureFieldSync(fieldId, attributeString) {
+            const field = state.fields.get(fieldId);
+            if (!field) return;
+            field.selected = parseAttributeString(attributeString);
+            ensureFallbackSelection(field.selected);
+            syncFieldValue(fieldId);
+        }
+
+        function isModalOpen() {
+            return !!(state.dom.modal && !state.dom.modal.classList.contains('hidden'));
+        }
+
+        function updateModalOptionState(name, sourceElement) {
+            const normalized = normalizeName(name);
+            if (!normalized || !state.dom.grid) {
+                return;
+            }
+
+            let targetButton = null;
+            if (sourceElement && sourceElement.dataset && sourceElement.dataset.attributeName === normalized) {
+                targetButton = sourceElement;
+            } else {
+                targetButton = state.optionRefs.get(normalized) || null;
+            }
+
+            if (!targetButton) {
+                return;
+            }
+
+            const isSelected = state.modalSelection.includes(normalized);
+            targetButton.setAttribute('aria-pressed', isSelected ? 'true' : 'false');
+            targetButton.classList.toggle('attribute-option--active', isSelected);
+            targetButton.classList.toggle('attribute-option--inactive', !isSelected);
+
+            const indicator = targetButton.querySelector('.attribute-option__indicator');
+            if (indicator) {
+                indicator.classList.toggle('attribute-option__indicator--active', isSelected);
+                indicator.classList.toggle('attribute-option__indicator--inactive', !isSelected);
+            }
+        }
+
+        const api = {
+            configure,
+            init,
+            registerField,
+            unregisterField,
+            rebuildFromAkyoData,
+            resetField,
+            hasSelection,
+            getValue,
+            setCurrentEditField,
+            clearCurrentEditField,
+            ensureFieldSync,
+            isModalOpen,
+            closeModal,
+            parseAttributeString,
+            serializeAttributes,
+            get currentEditFieldId() {
+                return state.currentEditFieldId;
+            }
+        };
+
+        return api;
+    }
+
+    const manager = createAttributeManagerInstance();
+
+    try {
+        Object.defineProperty(global, 'attributeManager', { value: manager, configurable: false, writable: false });
+    } catch (error) {
+        console.warn('[attributeManager] Unable to define read-only global, falling back to direct assignment', error);
+        global.attributeManager = manager;
+    }
+})(typeof window !== 'undefined' ? window : globalThis);


### PR DESCRIPTION
## Summary
- centralize Akyo image persistence and reuse the helper across add, edit, and bulk mapping workflows to improve quota handling and cleanup messaging
- normalize attribute parsing/serialization to enforce consistent CSV formatting and hidden field updates, and clarify auto-assigned ID behavior in the UI
- improve accessibility with alt text on image previews and gallery cards while updating CSV sync notifications to mention the local backup state

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7c3526fe08323a2c8ccddeb4ff018