### PR TITLE
Fix Finder author dropdown scrollbar styling

### DIFF
--- a/finder.html
+++ b/finder.html
@@ -319,6 +319,10 @@
             font-weight: 600;
         }
 
+        body.finder-body #addCreatorSuggestions {
+            overflow-x: hidden;
+        }
+
         .finder-ghost-btn:hover {
             background: rgba(249, 115, 22, 0.08);
         }


### PR DESCRIPTION
## Summary
- hide the horizontal scrollbar in the Finder mode existing author suggestion dropdown to remove the bottom bar while keeping vertical scrolling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da3a6322808323a0b4b525efa36e54