### PR TITLE
Refine Finder author dropdown scrollbar styling

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -55,6 +55,16 @@
             border-color: #667eea;
             background-color: #f7fafc;
         }
+
+        #addCreatorSuggestions {
+            overflow-y: auto;
+            overflow-x: hidden;
+        }
+
+        #addCreatorSuggestions::-webkit-scrollbar:horizontal {
+            height: 0;
+            display: none;
+        }
     </style>
 </head>
 <body class="bg-gradient-to-br from-gray-100 to-gray-200 min-h-screen">

--- a/finder.html
+++ b/finder.html
@@ -319,6 +319,16 @@
             font-weight: 600;
         }
 
+        body.finder-body #addCreatorSuggestions {
+            overflow-y: auto;
+            overflow-x: hidden;
+        }
+
+        body.finder-body #addCreatorSuggestions::-webkit-scrollbar:horizontal {
+            height: 0;
+            display: none;
+        }
+
         .finder-ghost-btn:hover {
             background: rgba(249, 115, 22, 0.08);
         }


### PR DESCRIPTION
## Summary
- hide the horizontal scrollbar in the Finder mode existing author suggestion dropdown to remove the bottom bar while keeping vertical scrolling
- ensure both Finder and admin suggestion panels suppress horizontal scrollbar tracks in WebKit-based browsers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da3a6322808323a0b4b525efa36e54