### PR TITLE
Keep Finder author suggestions white at rest

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -55,6 +55,16 @@
             border-color: #667eea;
             background-color: #f7fafc;
         }
+
+        #addCreatorSuggestions {
+            overflow-y: auto;
+            overflow-x: hidden;
+        }
+
+        #addCreatorSuggestions::-webkit-scrollbar:horizontal {
+            height: 0;
+            display: none;
+        }
     </style>
 </head>
 <body class="bg-gradient-to-br from-gray-100 to-gray-200 min-h-screen">

--- a/finder.html
+++ b/finder.html
@@ -319,6 +319,37 @@
             font-weight: 600;
         }
 
+        body.finder-body #addCreatorSuggestions {
+            overflow-y: auto;
+            overflow-x: hidden;
+            background: var(--finder-surface);
+            border: 1px solid rgba(249, 115, 22, 0.18);
+            box-shadow: 0 16px 32px rgba(249, 115, 22, 0.16);
+        }
+
+        body.finder-body #addCreatorSuggestions::-webkit-scrollbar:horizontal {
+            height: 0;
+            display: none;
+        }
+
+        body.finder-body #addCreatorSuggestions button {
+            background: var(--finder-surface);
+            background-image: none;
+            color: var(--finder-text-primary);
+            border-radius: 0.65rem;
+            transition: background-color 0.18s ease, color 0.18s ease;
+        }
+
+        body.finder-body #addCreatorSuggestions button:not(:first-child) {
+            border-top: 1px solid rgba(249, 115, 22, 0.1);
+        }
+
+        body.finder-body #addCreatorSuggestions button:hover,
+        body.finder-body #addCreatorSuggestions button:focus-visible {
+            background-color: rgba(249, 115, 22, 0.14);
+            color: var(--finder-accent-strong);
+        }
+
         .finder-ghost-btn:hover {
             background: rgba(249, 115, 22, 0.08);
         }


### PR DESCRIPTION
## Summary
- ensure the Finder existing-author suggestion dropdown stays on a neutral white surface by default instead of inheriting rainbow gradients
- apply Finder-accent hover and focus styling to the suggestion buttons while preserving the hidden horizontal scrollbar tweaks

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da3a6322808323a0b4b525efa36e54