### PR TITLE
Remove rainbow styling from author dropdown

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -61,6 +61,16 @@
             overflow-x: hidden;
         }
 
+        body:not(.finder-body) #addCreatorSuggestions {
+            background-color: #fff;
+            border: 1px solid rgba(209, 213, 219, 0.9);
+            box-shadow: 0 12px 25px rgba(15, 23, 42, 0.12);
+        }
+
+        body:not(.finder-body) #addCreatorSuggestions::before {
+            content: none;
+        }
+
         #addCreatorSuggestions::-webkit-scrollbar:horizontal {
             height: 0;
             display: none;


### PR DESCRIPTION
## Summary
- remove the rainbow gradient treatment from the existing author suggestions dropdown on the new registration tab
- keep a neutral white surface and subtle shadow so the list reads cleanly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da52645a9c83238067efcc4b10dc2f