### PR TITLE
Fix edit modal title styling

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -75,6 +75,15 @@
             height: 0;
             display: none;
         }
+
+        #editModal h2 {
+            background: none !important;
+            color: var(--text-primary, #1f2937) !important;
+            text-shadow: none !important;
+            animation: none !important;
+            -webkit-text-fill-color: currentColor !important;
+            -webkit-background-clip: border-box !important;
+        }
     </style>
 </head>
 <body class="bg-gradient-to-br from-gray-100 to-gray-200 min-h-screen">

--- a/finder.html
+++ b/finder.html
@@ -289,6 +289,15 @@
         .finder-modal-footer {
             background: rgba(254, 242, 242, 0.9);
         }
+
+        #editModal h2 {
+            background: none !important;
+            color: var(--finder-text-primary, #1f2937) !important;
+            text-shadow: none !important;
+            animation: none !important;
+            -webkit-text-fill-color: currentColor !important;
+            -webkit-background-clip: border-box !important;
+        }
 /* 属性管理モーダルをPC版同様の"緑"に統一する（finder.html） */
 #attributeModal {
   /* アクセント色（PC版のグリーン系に合わせる） */


### PR DESCRIPTION
## Summary
- override the edit modal title styling in finder mode to keep the heading neutral
- apply the same heading override in the admin page so the modal title no longer pulses in rainbow colors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da7512905c8323ac3f2a78d2897f88