### PR TITLE
Use VRChat thumbnail URLs when CDN assets are unavailable

### DIFF
--- a/index.html
+++ b/index.html
@@ -589,6 +589,18 @@
             // 画像エラーハンドラ（PNG→JPG→プレースホルダー）
             function handleImageError(img, id, color, mode) {
                 if (!img || !id) return;
+
+                const triedVrchat = img.dataset.triedVrchat === '1';
+                if (!triedVrchat && typeof window.getAkyoVrchatFallbackUrl === 'function') {
+                    const fallbackSize = mode === 'modal' ? 1024 : 512;
+                    const vrchatUrl = window.getAkyoVrchatFallbackUrl(id, { size: fallbackSize });
+                    if (vrchatUrl && img.src !== vrchatUrl) {
+                        img.dataset.triedVrchat = '1';
+                        img.src = vrchatUrl;
+                        return;
+                    }
+                }
+
                 const triedJpg = img.dataset.triedJpg === '1';
                 if (!triedJpg) {
                     img.dataset.triedJpg = '1';

--- a/js/image-loader.js
+++ b/js/image-loader.js
@@ -6,7 +6,7 @@
 // 形式3: ["001オリジン.png", ...]
 let akyoImageManifestMap = {};
 const PUBLIC_R2_BASE = 'https://images.akyodex.com';
-const VRCHAT_PROXY_ENDPOINT = '/api/vrc-avatar-image';
+const VRCHAT_THUMBNAIL_BASE = 'https://api.vrchat.cloud/api/1/avatars';
 
 function getAssetsVersionValue() {
     try {
@@ -168,12 +168,25 @@ function extractAvatarIdFromRecord(record) {
     return match ? match[0] : null;
 }
 
-function buildVrchatProxyUrl(avtrId, size, version) {
-    const params = new URLSearchParams();
-    params.set('avtr', avtrId);
-    params.set('w', String(size));
-    if (version) params.set('v', version);
-    return `${VRCHAT_PROXY_ENDPOINT}?${params.toString()}`;
+function buildVrchatDirectUrl(avtrId, size, version) {
+    if (!avtrId) return null;
+    const url = new URL(`${VRCHAT_THUMBNAIL_BASE}/${avtrId}/thumbnailimage`);
+    url.searchParams.set('size', String(size));
+    if (version) {
+        url.searchParams.set('v', version);
+    }
+    return url.toString();
+}
+
+function resolveVrchatThumbnailUrl(akyoId, size, versionValue) {
+    try {
+        const record = findAkyoRecord(akyoId);
+        const avtrId = extractAvatarIdFromRecord(record);
+        if (!avtrId) return null;
+        return buildVrchatDirectUrl(avtrId, size, versionValue);
+    } catch (_) {
+        return null;
+    }
 }
 
 // 画像の遅延読み込み設定
@@ -201,40 +214,51 @@ function setupLazyLoading() {
 }
 
 // 画像URLを取得
+function appendVersionIfNeeded(url, versionValue) {
+    if (!url || !versionValue) return url;
+    if (/[?&]v=/.test(url)) return url;
+    return `${url}${url.includes('?') ? '&' : '?'}v=${encodeURIComponent(versionValue)}`;
+}
+
+function tryGetManifestUrl(manifest, akyoId, versionValue, versionSuffix) {
+    const value = manifest && manifest[akyoId];
+    if (typeof value !== 'string') return null;
+
+    if (/^https?:\/\//.test(value)) {
+        return appendVersionIfNeeded(value, versionValue);
+    }
+
+    if (value.startsWith('/') || value.startsWith('images/')) {
+        return appendVersionIfNeeded(value, versionValue) || `${value}${versionSuffix}`;
+    }
+
+    const relative = `images/${value}`;
+    return appendVersionIfNeeded(relative, versionValue) || `${relative}${versionSuffix}`;
+}
+
 function getAkyoImageUrl(akyoIdLike, options = {}) {
     const akyoId = String(akyoIdLike || '').padStart(3, '0');
     const size = Math.max(32, Math.min(4096, parseInt(options.size || '512', 10) || 512));
     const versionValue = getAssetsVersionValue();
     const versionSuffix = versionValue ? `?v=${encodeURIComponent(versionValue)}` : '';
 
-    // まずwindowにロードされたマニフェストを優先
+    // 1) マニフェスト（window側が優先）
     try {
-        if (typeof window !== 'undefined' && window.akyoImageManifestMap && window.akyoImageManifestMap[akyoId]) {
-            const v = window.akyoImageManifestMap[akyoId];
-            if (typeof v === 'string' && /^https?:\/\//.test(v)) {
-                return versionValue && !/[?&]v=/.test(v) ? `${v}${v.includes('?') ? '&' : '?'}v=${encodeURIComponent(versionValue)}` : v;
-            }
-            return `images/${v}${versionSuffix}`;
+        if (typeof window !== 'undefined' && window.akyoImageManifestMap) {
+            const manifestUrl = tryGetManifestUrl(window.akyoImageManifestMap, akyoId, versionValue, versionSuffix);
+            if (manifestUrl) return manifestUrl;
         }
     } catch (_) {}
-    // マニフェストから探す
-    if (akyoImageManifestMap && akyoImageManifestMap[akyoId]) {
-        const val = akyoImageManifestMap[akyoId];
-        if (typeof val === 'string') {
-            // 1) フルURL
-            if (/^https?:\/\//.test(val)) {
-                return versionValue && !/[?&]v=/.test(val) ? `${val}${val.includes('?') ? '&' : '?'}v=${encodeURIComponent(versionValue)}` : val;
-            }
-            // 2) 先頭がスラッシュ、または既に images/ を含む相対パス
-            if (val.startsWith('/') || val.startsWith('images/')) {
-                return `${val}${versionSuffix}`;
-            }
-            // 3) 純粋なファイル名
-            return `images/${val}${versionSuffix}`;
-        }
-    }
 
-    // 次にローカルストレージから探す
+    // 2) ローカルコピーのマニフェスト
+    const manifestUrl = tryGetManifestUrl(akyoImageManifestMap, akyoId, versionValue, versionSuffix);
+    if (manifestUrl) return manifestUrl;
+
+    // 3) VRChat 直リンク
+    const vrchatUrl = resolveVrchatThumbnailUrl(akyoId, size, versionValue);
+    if (vrchatUrl) return vrchatUrl;
+
+    // 4) ユーザーのローカル保存データ
     try {
         const savedImages = localStorage.getItem('akyoImages');
         if (savedImages) {
@@ -245,23 +269,7 @@ function getAkyoImageUrl(akyoIdLike, options = {}) {
         }
     } catch (_) {}
 
-    // VRChat直リンクにフォールバック
-    try {
-        const record = findAkyoRecord(akyoId);
-        const avtrId = extractAvatarIdFromRecord(record);
-        if (avtrId) {
-            return buildVrchatProxyUrl(avtrId, size, versionValue);
-        }
-    } catch (_) {}
-
-    // R2直URL（最後の手段）
-    try {
-        if (PUBLIC_R2_BASE) {
-            return `${PUBLIC_R2_BASE}/${akyoId}.webp${versionSuffix}`;
-        }
-    } catch (_) {}
-
-    // 最後のフォールバック: デプロイ先の静的フォルダ images/{id}.webp
+    // 5) 最終フォールバック
     return `images/${akyoId}.webp${versionSuffix}`;
 }
 
@@ -271,6 +279,15 @@ if (typeof module !== 'undefined' && module.exports) {
 }
 
 if (typeof window !== 'undefined') {
+    if (typeof window.PUBLIC_R2_BASE === 'undefined') {
+        window.PUBLIC_R2_BASE = PUBLIC_R2_BASE;
+    }
     window.loadImagesManifest = loadImagesManifest;
     window.getAkyoImageUrl = getAkyoImageUrl;
+    window.getAkyoVrchatFallbackUrl = function getAkyoVrchatFallbackUrl(idLike, options = {}) {
+        const akyoId = String(idLike || '').padStart(3, '0');
+        const size = Math.max(32, Math.min(4096, parseInt(options.size || '512', 10) || 512));
+        const versionValue = getAssetsVersionValue();
+        return resolveVrchatThumbnailUrl(akyoId, size, versionValue);
+    };
 }


### PR DESCRIPTION
## Summary
- resolve Akyo image URLs by falling back to VRChat thumbnail endpoints whenever the manifest lacks an R2 entry before checking any local caches
- expose a shared helper for retrieving VRChat image URLs and use it across the main gallery and admin tools to keep previews working even without the proxy function
- retry image loads in the UI by requesting the VRChat thumbnail once before dropping to static JPG or placeholders

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da88fc24708323b8d34cb51cc3fa88