### PR TITLE
Ensure edit modal header is white

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -440,7 +440,10 @@
         <div class="relative flex items-center justify-center min-h-screen p-4">
             <div class="bg-white rounded-2xl shadow-2xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
                 <div class="sticky top-0 bg-white border-b p-4 flex justify-between items-center">
-                    <h2 class="text-2xl font-bold">Akyoを編集</h2>
+                    <h2 class="text-2xl font-bold flex items-center">
+                        <i class="fas fa-edit text-blue-500 mr-2"></i>
+                        Akyoを編集
+                    </h2>
                     <button onclick="closeEditModal()" class="text-gray-500 hover:text-gray-700">
                         <i class="fas fa-times text-2xl"></i>
                     </button>

--- a/css/kid-friendly.css
+++ b/css/kid-friendly.css
@@ -457,6 +457,16 @@ select:focus {
     padding: 20px !important;
     border-radius: 26px 26px 0 0 !important;
 }
+#editModal .sticky {
+    background: #ffffff !important;
+    border-bottom: 1px solid rgba(209, 213, 219, 0.6) !important;
+    box-shadow: none !important;
+}
+
+#editModal .sticky::before {
+    content: none !important;
+}
+
 #editModal h2 {
     background: none !important;
     color: var(--text-primary) !important;

--- a/finder.html
+++ b/finder.html
@@ -754,7 +754,10 @@ aria-label="通称の重複チェック">
         <div class="relative flex items-center justify-center min-h-screen p-4">
             <div class="bg-white rounded-2xl shadow-2xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
                 <div class="sticky top-0 bg-white border-b p-4 flex justify-between items-center">
-                    <h2 class="text-2xl font-bold">Akyoを編集</h2>
+                    <h2 class="text-2xl font-bold flex items-center">
+                        <i class="fas fa-edit text-blue-500 mr-2"></i>
+                        Akyoを編集
+                    </h2>
                     <button onclick="closeEditModal()" class="text-gray-500 hover:text-gray-700">
                         <i class="fas fa-times text-2xl"></i>
                     </button>


### PR DESCRIPTION
## Summary
- force the edit modal header to render with a plain white background and subtle gray divider
- remove the decorative pseudo-element so the edit header stays neutral while retaining existing typography overrides
- add the blue edit icon to the "Akyoを編集" modal header so it matches the related management section iconography

## Testing
- not run (frontend change)


------
https://chatgpt.com/codex/tasks/task_e_68da8e7a56648323bf8a2ff9467e8f74