### PR TITLE
Investigate AkyoGallery link redirection issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -304,7 +304,7 @@
           <div class="hidden md:block h-8 w-px bg-gray-300"></div>
 
           <!-- Gallery ロゴ -->
-          <a href="https://gallery.akyodex.com"
+          <a href="/gallery/"
              class="flex items-center opacity-70 hover:opacity-100 transition-opacity"
              title="AkyoGallery">
             <img src="/images/akyogallery.webp" alt="AkyoGallery" class="h-8 md:h-10 lg:h-12">


### PR DESCRIPTION
Change the AkyoGallery logo link to a relative path (`/gallery/`) to ensure correct navigation to the AkyoGallery page.

The previous absolute URL (`https://gallery.akyodex.com`) caused an incorrect redirection to the old Akyo Encyclopedia homepage. By using a relative path, the link now correctly displays `gallery.html` within the same origin.

---
<a href="https://cursor.com/background-agent?bcId=bc-b9ef4cd8-77fb-489e-9264-20255afcd66d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b9ef4cd8-77fb-489e-9264-20255afcd66d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

