### PR TITLE
Add 48px favicon references for search results

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Akyoずかん - ファインダーモード</title>
     <!-- Favicon -->
+    <link rel="icon" type="image/png" sizes="48x48" href="images/akyodexIcon-48.png?v=20250927">
     <link rel="icon" type="image/png" sizes="32x32" href="images/akyodexIcon-32.png?v=20250926">
     <link rel="icon" type="image/png" sizes="16x16" href="images/akyodexIcon-16.png?v=20250926">
     <!-- iOSアイコン -->

--- a/finder.html
+++ b/finder.html
@@ -7,6 +7,7 @@
     <!-- iOSアイコン -->
     <link rel="apple-touch-icon" sizes="180x180" href="images/apple-touch-icon-180.png">
     <!-- Favicon -->
+    <link rel="icon" type="image/png" sizes="48x48" href="images/akyodexIcon-48.png?v=20250927">
     <link rel="icon" type="image/png" sizes="32x32" href="images/akyodexIcon-32.png?v=20250926">
     <link rel="icon" type="image/png" sizes="16x16" href="images/akyodexIcon-16.png?v=20250926">
     <title>Akyoずかん - ファインダーモード</title>

--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
     <!-- iOSアイコン -->
     <link rel="apple-touch-icon" sizes="180x180" href="images/apple-touch-icon-180.png">
     <!-- Favicon -->
+    <link rel="icon" type="image/png" sizes="48x48" href="images/akyodexIcon-48.png?v=20250927">
     <link rel="icon" type="image/png" sizes="32x32" href="images/akyodexIcon-32.png?v=20250926">
     <link rel="icon" type="image/png" sizes="16x16" href="images/akyodexIcon-16.png?v=20250926">
 

--- a/logo-upload.html
+++ b/logo-upload.html
@@ -5,6 +5,7 @@
     <link rel="manifest" href="/manifest.webmanifest">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Favicon -->
+    <link rel="icon" type="image/png" sizes="48x48" href="images/akyodexIcon-48.png?v=20250927">
     <link rel="icon" type="image/png" sizes="32x32" href="images/akyodexIcon-32.png?v=20250926">
     <link rel="icon" type="image/png" sizes="16x16" href="images/akyodexIcon-16.png?v=20250926">
     <!-- iOSアイコン -->

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -13,6 +13,7 @@
     { "src": "/images/akyodexIcon-192.png", "sizes": "192x192", "type": "image/png", "purpose": "any" },
     { "src": "/images/akyodexIcon-512.png", "sizes": "512x512", "type": "image/png", "purpose": "any maskable" },
     { "src": "/images/akyodexIcon-16.png", "sizes": "16x16", "type": "image/png", "purpose": "any" },
-    { "src": "/images/akyodexIcon-32.png", "sizes": "32x32", "type": "image/png", "purpose": "any" }
+    { "src": "/images/akyodexIcon-32.png", "sizes": "32x32", "type": "image/png", "purpose": "any" },
+    { "src": "/images/akyodexIcon-48.png", "sizes": "48x48", "type": "image/png", "purpose": "any" }
   ]
 }

--- a/share.html
+++ b/share.html
@@ -8,6 +8,7 @@
     <meta name="robots" content="noindex,follow">
     <link rel="canonical" href="https://akyodex.com/">
     <!-- Favicon -->
+    <link rel="icon" type="image/png" sizes="48x48" href="images/akyodexIcon-48.png?v=20250927">
     <link rel="icon" type="image/png" sizes="32x32" href="images/akyodexIcon-32.png?v=20250926">
     <link rel="icon" type="image/png" sizes="16x16" href="images/akyodexIcon-16.png?v=20250926">
     <meta property="og:type" content="website">


### PR DESCRIPTION
## Summary
- add the new 48x48 PNG favicon link to each HTML page so crawlers can discover it
- register the 48px icon in the web manifest for consistency with the new asset

## Testing
- not run (static changes)


------
https://chatgpt.com/codex/tasks/task_e_68e3509a0170832397ba576c7168f070