### PR TITLE
Group admin and Dify controls in floating quick access row

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -456,6 +456,11 @@ function updateStaticTextContent(lang = currentLanguage) {
         difyBtn.title = difyTitle;
         difyBtn.setAttribute('aria-label', difyTitle);
     }
+
+    const quickAccessRow = document.getElementById('quickAccessRow');
+    if (quickAccessRow) {
+        quickAccessRow.setAttribute('aria-label', lang === 'ja' ? 'クイックアクセス操作' : 'Quick access actions');
+    }
 }
 
 function updatePreferredLogoPath() {
@@ -1459,7 +1464,10 @@ function setupEventListeners() {
     floatingContainer.appendChild(languageBtn);
 
     const quickAccessRow = document.createElement('div');
-    quickAccessRow.className = 'flex items-center gap-3 flex-wrap sm:flex-nowrap';
+    quickAccessRow.id = 'quickAccessRow';
+    quickAccessRow.className = 'mt-3 flex items-center gap-3 flex-wrap sm:flex-nowrap';
+    quickAccessRow.setAttribute('role', 'group');
+    quickAccessRow.setAttribute('aria-label', currentLanguage === 'ja' ? 'クイックアクセス操作' : 'Quick access actions');
     floatingContainer.appendChild(quickAccessRow);
 
     const difyBtn = document.createElement('button');


### PR DESCRIPTION
## Summary
- wrap the floating admin and Dify controls in a shared quick-access row appended after the language switcher
- add group semantics and localized aria-labels so the quick-access buttons remain accessible as the language changes

## Testing
- python3 -m http.server 8000
- manual verification of desktop and mobile layouts via Playwright screenshots


------
https://chatgpt.com/codex/tasks/task_e_68e4e6da797483239d63bb9efe042711