### PR TITLE
Add Dify fallback for Pages preview hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,6 +656,12 @@ npx wrangler pages deploy dist --project-name akyodex-site
 
 ---
 
+### トラブルシューティング
+
+- Cloudflare Tunnel 経由で Dify ウィジェットが 403/502 エラーになる場合は、[Cloudflare Tunnel 経由で Dify 埋め込みを配信する手順](docs/cloudflare-tunnel-dify.md) を参照してください（502 のときはトンネル先のアプリがリッスンしているポートも確認）。`curl` で 200 OK が返るようになった後は、ハードリロードしてチャットバブルが前面で開くかを確認し、Cloudflare Pages のプレビュー URL でバブルが出ないときはページ右下に出る「AIチャット」ボタン（新しいウィンドウで開く fallback）と同ガイドのプレビュー向け節を使って切り分けます。
+
+---
+
 ### 完了後の運用メモ
 
 - 画像の追加・差し替えは管理画面から実行（再デプロイ不要）。

--- a/docs/cloudflare-tunnel-dify.md
+++ b/docs/cloudflare-tunnel-dify.md
@@ -1,0 +1,107 @@
+# Cloudflare Tunnel 経由で Dify 埋め込みを配信する手順
+
+Dify の埋め込みウィジェット (`embed.min.js`) は HTTPS で配信され、外部からの直接アクセスを許可しておく必要があります。Cloudflare Tunnel/Zero Trust を HTTP プロキシとして経由させている環境では、トンネル側のアクセス制御でブロックされると 403 応答になり、フロントエンドからチャットボットが読み込めません。このページでは、Cloudflare Tunnel と Zero Trust の設定で **埋め込み用エンドポイントを許可する方法** をまとめています。
+
+## 1. 事象の確認
+
+1. Cloudflare Tunnel を経由しているマシンから以下を実行し、HTTP ステータスを確認します。
+   ```bash
+   curl -v https://dexakyo.akyodex.com/embed.min.js
+   ```
+2. 返却されるステータスコードに応じて切り分けます。
+   - `403 Forbidden` … トンネル配下の HTTP プロキシ/Zero Trust Gateway が外向き通信を拒否しています（後述の「Zero Trust Gateway でドメインを許可する」を参照）。
+   - `502 Bad Gateway` … Cloudflare がトンネルのオリジンサービスに接続できていません。`cloudflared` サービスまたはオリジン自体が停止していないか、証明書/TLS 設定に問題がないかを確認します。
+   - それ以外のコード … Zero Trust の **Logs** → **Gateway** と `cloudflared` のログを突き合わせて原因を特定します。
+3. Windows PowerShell の `Invoke-WebRequest`/`curl` でも同様に確認できます。環境依存の HTTP プロキシではなく Cloudflare から 502 が返っている場合は、トンネルがオリジンサービスを解決できていない可能性が高いです。
+
+## 2. Zero Trust Gateway でドメインを許可する
+
+1. Cloudflare ダッシュボード → **Zero Trust** → **Gateway** → **Policies** → **HTTP** を開きます。
+2. `dexakyo.akyodex.com`（または Dify のホスト名）が対象になっている「Block」ルールがあれば削除するか、優先度を下げます。
+3. 新しい **Allow** ポリシーを追加し、以下の条件を設定します。
+   - **Selector**: Domain
+   - **Operator**: is
+   - **Value**: `dexakyo.akyodex.com`
+4. ポリシーの適用先（ユーザーグループやデバイスプロファイル）が、埋め込みスクリプトを取得したいマシンを含んでいることを確認します。
+
+> ゲートウェイポリシーに変更を加えた後は、`cloudflared`/WARP クライアント側で数分待つか、`warp-cli` を再起動して最新ポリシーを取得します。
+
+## 3. Cloudflare Tunnel (cloudflared) の設定を確認する
+
+Zero Trust での許可に加えて、cloudflared のトンネル設定でも HTTPS の透過プロキシが有効になっていることを確認します。
+
+1. サーバー側の `cloudflared` 構成ファイル（例：`/etc/cloudflared/config.yml`）を開き、以下のような `ingress` ルールがあることを確認します。
+   ```yaml
+   tunnel: <YOUR_TUNNEL_ID>
+   credentials-file: /etc/cloudflared/<YOUR_TUNNEL_ID>.json
+
+   ingress:
+     - hostname: dexakyo.akyodex.com
+       service: https://<origin-service-host>:<port>
+     - service: http_status:404
+   ```
+2. オリジンサービスが自己署名証明書などを使用している場合は、`originRequest: { noTLSVerify: true }` を `hostname` のブロック内に追加します。
+3. 設定を更新したら `cloudflared service restart` でトンネルを再起動し、ログにエラーがないか確認します。
+4. 502 が解消しない場合は、以下を追加でチェックします。
+   - `cloudflared tunnel info <YOUR_TUNNEL_NAME>` でコネクタのオンライン状況を確認する。
+   - `cloudflared` ログに `connection refused` や `handshake failure` が記録されていないか確認する。
+   - オリジンサーバーが HTTPS で待ち受けているポートに直接アクセスし、期待通りに `embed.min.js` が配信されるかテストする（例：`curl -k https://<origin-service-host>:<port>/embed.min.js`）。
+   - Cloudflare Zero Trust → **Access** → **Tunnels** でトンネルのヘルスチェックが「Healthy」になっているか確認する。
+
+## 4. オリジンサービスとポートの稼働状況を確認する
+
+Cloudflare が 502 を返している場合、Zero Trust の設定が正しくても **トンネルの先にあるオリジンサービスが停止している** 可能性が
+あります。以下の手順で、トンネル先のホストおよび開放ポートが稼働中か確認してください。
+
+1. `cloudflared` を実行しているマシン、またはオリジンサービスが動作しているマシンに接続します。
+2. Linux/macOS の場合:
+   ```bash
+   sudo netstat -tulpn | grep <port>
+   ```
+   Windows PowerShell の場合:
+   ```powershell
+   netstat -ano | findstr <port>
+   ```
+   いずれのコマンドも結果が空であれば、そのポートで待ち受けているプロセスが存在しません。アプリケーションを起動し直し、サービスが
+   正しくバインドされているか確認してください。
+3. オリジンサービスが別ホストで稼働している場合は、トンネルホストから直接アクセスできるかを `curl -k https://<origin-host>:<port>/embed.min.js`
+   などで確認します。ここで接続エラーが発生する場合、Cloudflare からも到達できません。
+4. Windows クライアント側で `curl` を実行して 502 が返り、かつ `netstat -ano | findstr <port>` で該当ポートが表示されない場合は、オリ
+   ジンのアプリケーションが停止しているか、別ポートで起動していると考えられます。アプリを再起動するか、設定ファイルのポート番号を
+   Cloudflare Tunnel の `service` 設定と一致させてください。
+
+## 5. (任意) Cloudflare Access を利用して保護する場合
+
+埋め込みエンドポイントを完全公開にしたくない場合は、Access サービス トークンで保護したうえで、フロントエンドからトークンを付与する方法があります。
+
+1. Zero Trust → **Access** → **Service Tokens** でクライアント ID/Secret を発行します。
+2. `index.html` など埋め込みを行うページで、`CF-Access-Client-Id` と `CF-Access-Client-Secret` を HTTP ヘッダーに追加できるよう、リバースプロキシまたは Functions を経由させます（静的サイトの場合は Functions/Workers でヘッダーを付与するのが簡単です）。
+3. 発行したトークンを Vault など安全なストレージに保管し、必要に応じてローテーションします。
+
+## 6. 動作確認
+
+設定後に再度以下の手順で確認します。
+
+1. トンネル経由の環境で `curl https://dexakyo.akyodex.com/embed.min.js` を実行し、200 応答とファイル本文が取得できることを確認する。
+2. 200 OK が返ってもブラウザのキャッシュで古いスクリプトが保持されている場合があるため、`Ctrl` + `Shift` + `R`（macOS は `Cmd` + `Shift` + `R`）でハードリロードするか、開発者ツールを開いて **Disable cache** を有効にしてから再読み込みしてください。
+3. サイトをブラウザで開き、JavaScript コンソールに 403/アクセス拒否エラーが出ないこと、および Dify ウィジェットが表示されることを確認する。
+4. バブルが表示されているにもかかわらずクリックしても反応しない場合は、`js/main.js` の `floatingContainer` など他要素の `z-index` が衝突していないか確認し、必要に応じて調整します。
+
+これらの設定が揃えば、Cloudflare Tunnel を利用する環境でも Dify の埋め込みスクリプトを問題なく読み込めます。ウィジェットが前面に出てチャット画面が開くことまで確認できれば、トンネルの設定は完了です。
+
+## 7. Cloudflare Pages プレビューでバブルが表示されない場合
+
+Cloudflare Pages のプレビュー URL（`*.pages.dev`）は、Dify 側で **Website embedding → Allowed domains** に追加していないとウィジェットが描画されません。プレビューで以下の現象が出る場合は、本番ドメインと同じようにプレビューのホスト名も許可してください。
+
+- ページ読み込み後 10 秒以内に `dify-chatbot-bubble` 要素が DOM に現れない。
+- ブラウザのコンソールに `[Dify] Chatbot bubble did not render (bubble-timeout)` の警告と「Cloudflare Pages preview hosts must be added...」というメッセージが出る。
+- 右下に「AIチャット (別ウィンドウ)」ボタンが表示され、そちらから開くとチャット自体は利用できる。
+
+### 対処フロー
+
+1. Dify の管理画面 → **Settings** → **Website embedding** → **Allowed domains** に移動し、プレビューのホスト名（例：`https://eac66113.akyodex.pages.dev`）を追加します。
+2. 保存後にプレビューをハードリロードし、チャットバブルが表示されるか確認します。
+3. バブルが出ない場合でも、右下の fallback ボタン（`AIチャット (別ウィンドウ)` / `AI chat (new tab)`）から Dify のベース URL が開けるか確認し、外部からのアクセス自体が通っているかを切り分けてください。
+4. fallback でも開けない場合は、`curl` で 200 OK になるかを再度確認し、Zero Trust / Tunnel 側でのフィルタリングを見直します。
+
+プレビュー環境特有の制限をクリアすれば、本番ドメインと同じように埋め込みウィジェットが表示されます。

--- a/index.html
+++ b/index.html
@@ -467,7 +467,7 @@
             lang: 'ja',
             layout: {
                 position: 'right',
-                zIndex: 2147483640
+                zIndex: 2147483648
             },
             appearance: {
                 primaryColor: '#f97316'

--- a/js/main.js
+++ b/js/main.js
@@ -44,6 +44,8 @@ const LANGUAGE_CONFIG = {
         toggleAria: '英語版ホームページに切り替える',
         adminButtonTitle: 'ファインダーモード',
         chatbotButtonTitle: 'Difyチャットを開く',
+        chatbotFallbackLabel: 'AIチャット (別ウィンドウ)',
+        chatbotFallbackTooltip: 'Difyチャットが表示されないときはこちら',
         strings: {
             searchPlaceholder: 'Akyoを検索... (名前、ID、属性など)',
             attributePlaceholder: 'すべての属性',
@@ -99,7 +101,9 @@ const LANGUAGE_CONFIG = {
                 reloadFailed: '最新データの取得に失敗しました。再試行してください。',
                 partialLoadFailed: '一部の読み込みに失敗しました。ページを更新するか再試行してください。',
                 initFailed: '初期化に失敗しました。再読み込みしますか？',
-                retry: '再試行'
+                retry: '再試行',
+                difyUnavailable: 'AIチャットが表示されません。右下の「AIチャット」ボタンから新しいウィンドウで開けます。',
+                difyPreviewNotice: 'Cloudflare Pages プレビューでは AI チャットが非表示になる場合があります。本番ドメインを開くか、Dify 側でプレビューのホスト名を許可してください。'
             }
         }
     },
@@ -121,6 +125,8 @@ const LANGUAGE_CONFIG = {
         toggleAria: '日本語版ホームページに切り替える',
         adminButtonTitle: 'Finder mode',
         chatbotButtonTitle: 'Open Dify chat',
+        chatbotFallbackLabel: 'AI chat (new tab)',
+        chatbotFallbackTooltip: 'Use this if the Dify chat bubble does not appear',
         strings: {
             searchPlaceholder: 'Search Akyo... (name, ID, attributes)',
             attributePlaceholder: 'All attributes',
@@ -176,7 +182,9 @@ const LANGUAGE_CONFIG = {
                 reloadFailed: 'Failed to fetch the latest data. Please try again.',
                 partialLoadFailed: 'Some content failed to load. Refresh the page or try again.',
                 initFailed: 'Initialization failed. Reload the page?',
-                retry: 'Retry'
+                retry: 'Retry',
+                difyUnavailable: 'The AI chat widget did not appear. Use the "AI chat" button to open it in a new tab.',
+                difyPreviewNotice: 'AI chat can stay hidden on Cloudflare Pages previews. Visit the production domain or allow the preview host in Dify.'
             }
         }
     }
@@ -207,6 +215,77 @@ function openDifyChatbotFallback() {
             GLOBAL_SCOPE.location.assign(DIFY_CHATBOT_URL);
         }
     } catch (_) {}
+}
+
+function updateChatbotFallbackButton(lang = currentLanguage) {
+    const btn = document.getElementById('difyFallbackBtn');
+    if (!btn) return;
+    const config = getLanguageConfig(lang);
+    const label = config.chatbotFallbackLabel || config.chatbotButtonTitle || 'AI chat';
+    const tooltip = config.chatbotFallbackTooltip || config.chatbotButtonTitle || label;
+    btn.textContent = label;
+    btn.title = tooltip;
+    btn.setAttribute('aria-label', tooltip);
+}
+
+function initDifyEmbedDiagnostics() {
+    if (typeof document === 'undefined') return;
+
+    const host = typeof window !== 'undefined' ? window.location.hostname : '';
+    const isPagesPreview = typeof host === 'string' && /\.pages\.dev$/i.test(host);
+    const fallbackButton = document.getElementById('difyFallbackBtn');
+    let fallbackShown = false;
+    let bubbleFound = false;
+
+    const revealFallback = (reason) => {
+        if (fallbackShown) return;
+        fallbackShown = true;
+
+        if (fallbackButton) {
+            fallbackButton.style.display = '';
+            fallbackButton.classList.remove('hidden');
+            fallbackButton.disabled = false;
+        }
+
+        const strings = getLanguageStrings();
+        const notice = isPagesPreview && strings.messages.difyPreviewNotice
+            ? strings.messages.difyPreviewNotice
+            : strings.messages.difyUnavailable;
+        if (notice) {
+            showToast(notice, 'warning');
+        }
+
+        const diagnosticMessage = `[Dify] Chatbot bubble did not render (${reason}). Current host: ${host || 'unknown'}.`;
+        console.warn(diagnosticMessage);
+        if (isPagesPreview) {
+            console.warn('[Dify] Cloudflare Pages preview hosts must be added to the allowed domain list in Dify → Settings → Website embedding.');
+        }
+    };
+
+    const embedScript = document.querySelector('script[src^="https://dexakyo.akyodex.com/embed"]');
+    if (!embedScript) {
+        revealFallback('script-tag-missing');
+        return;
+    }
+
+    embedScript.addEventListener('error', () => {
+        revealFallback('script-load-error');
+    });
+
+    const interval = window.setInterval(() => {
+        if (document.querySelector('dify-chatbot-bubble')) {
+            bubbleFound = true;
+            window.clearInterval(interval);
+            console.debug('[Dify] Chatbot bubble detected.');
+        }
+    }, 600);
+
+    window.setTimeout(() => {
+        window.clearInterval(interval);
+        if (!bubbleFound) {
+            revealFallback('bubble-timeout');
+        }
+    }, 9000);
 }
 
 function safeGetLocalStorage(key) {
@@ -262,6 +341,7 @@ window.akyoCurrentLanguage = currentLanguage;
 updateDocumentLanguageAttributes();
 updatePreferredLogoPath();
 updateStaticTextContent();
+updateChatbotFallbackButton();
 
 function getLanguageConfig(lang = currentLanguage) {
     return LANGUAGE_CONFIG[lang] || LANGUAGE_CONFIG.ja;
@@ -477,6 +557,7 @@ async function setLanguage(lang) {
     safeSetLocalStorage(LANGUAGE_STORAGE_KEY, lang);
     updateDocumentLanguageAttributes(lang);
     updateLanguageToggleButton();
+    updateChatbotFallbackButton(lang);
     updatePreferredLogoPath();
     updateStaticTextContent(lang);
     updateQuickFilterStyles();
@@ -928,6 +1009,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     // イベントリスナーの設定を最初に実行（UIの応答性向上）
     setupEventListeners();
+    initDifyEmbedDiagnostics();
 
     // 初期表示を先に実行（ローディング表示など）
     document.getElementById('noDataContainer').classList.remove('hidden');
@@ -1441,8 +1523,8 @@ function setupEventListeners() {
         && typeof window.CSS.supports === 'function'
         && window.CSS.supports('padding-bottom: env(safe-area-inset-bottom)');
     const safeAreaInset = supportsSafeArea ? 'env(safe-area-inset-bottom)' : '0px';
-    floatingContainer.style.bottom = `calc(6rem + ${safeAreaInset})`;
-    floatingContainer.style.zIndex = '2147483646';
+    floatingContainer.style.bottom = `calc(9rem + ${safeAreaInset})`;
+    floatingContainer.style.zIndex = '2147483600';
 
     const languageBtn = document.createElement('button');
     languageBtn.id = 'languageToggleBtn';
@@ -1469,8 +1551,20 @@ function setupEventListeners() {
     });
     floatingContainer.appendChild(adminBtn);
 
+    const difyFallbackBtn = document.createElement('button');
+    difyFallbackBtn.id = 'difyFallbackBtn';
+    difyFallbackBtn.type = 'button';
+    difyFallbackBtn.className = 'bg-blue-600 text-white px-4 py-2 rounded-full shadow-lg hover:bg-blue-500 transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-200 hidden';
+    difyFallbackBtn.style.display = 'none';
+    difyFallbackBtn.disabled = true;
+    difyFallbackBtn.addEventListener('click', () => {
+        openDifyChatbotFallback();
+    });
+    floatingContainer.appendChild(difyFallbackBtn);
+
     document.body.appendChild(floatingContainer);
     updateLanguageToggleButton();
+    updateChatbotFallbackButton();
     updateStaticTextContent();
 
     // モーダルクローズ


### PR DESCRIPTION
## Summary
- add runtime diagnostics that expose a fallback AI chat button when the Dify embed script fails to render (e.g., on Cloudflare Pages preview hosts)
- extend the Cloudflare Tunnel/Dify troubleshooting guide with a section on allowing preview domains and explain the new fallback workflow
- mention the fallback button in the README troubleshooting checklist so operators know how to proceed after a successful curl check

## Testing
- Not run (browser-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e4f710dd988323a120dca0600fb5b6