### PR TITLE
Adjust floating controls z-index for Dify overlay

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1558,7 +1558,8 @@ function setupEventListeners() {
         && window.CSS.supports('padding-bottom: env(safe-area-inset-bottom)');
     const safeAreaInset = supportsSafeArea ? 'env(safe-area-inset-bottom)' : '0px';
     floatingContainer.style.bottom = `calc(9rem + ${safeAreaInset})`;
-    floatingContainer.style.zIndex = '2147483600';
+    // Allow the Dify chatbot window to stack above the floating controls.
+    floatingContainer.style.zIndex = '2147483000';
 
     const languageBtn = document.createElement('button');
     languageBtn.id = 'languageToggleBtn';


### PR DESCRIPTION
## Summary
- lower the floating floating-container z-index so the Dify chatbot window can appear on top of the toolbar controls

## Testing
- python3 -m http.server 8000 (verified layout manually; Dify embed script blocked by upstream 403 in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e5273e035c8323a60ddc7e96559bb8