### PR TITLE
Align Dify chat button styling with language toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -564,16 +564,38 @@
     console.log('[Dify Fix] Waiting for button and iframe...');
     
     let attempts = 0;
+    let stylesApplied = false;
     const maxAttempts = 100; // 10秒間
     
     const setupClickHandler = () => {
         const button = document.getElementById('dify-chatbot-bubble-button');
         const iframe = document.getElementById('dify-chatbot-bubble-window');
-        
+
+        if (button && !stylesApplied) {
+            button.style.setProperty('background-color', '#f97316', 'important');
+            button.style.setProperty('color', '#ffffff', 'important');
+            button.style.setProperty('border-color', '#ea580c', 'important');
+            button.style.setProperty('box-shadow', '0 10px 15px -3px rgba(249, 115, 22, 0.4), 0 4px 6px -4px rgba(249, 115, 22, 0.5)', 'important');
+            button.style.setProperty('transition', 'all 0.3s ease', 'important');
+
+            button.classList.add(
+                'text-white',
+                'shadow-lg',
+                'hover:bg-orange-400',
+                'transition',
+                'focus:outline-none',
+                'focus:ring-2',
+                'focus:ring-offset-2',
+                'focus:ring-orange-200'
+            );
+
+            stylesApplied = true;
+        }
+
         if (!button || !iframe) {
             return false;
         }
-        
+
         console.log('[Dify Fix] Button and iframe found');
         
         // クリックイベントを設定（クローンせずに直接）


### PR DESCRIPTION
## Summary
- apply the language toggle color scheme to the Dify chat bubble button once it loads
- add styling guards so the interval retry loop keeps running without duplicating style work

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e66241ffd48323985513d923d267a3