### PR TITLE
Fix Dify chat responsiveness on mobile devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -584,15 +584,22 @@
             iframe.style.setProperty('z-index', '2147483650', 'important');
             iframe.style.setProperty('visibility', 'visible', 'important');
             iframe.style.setProperty('opacity', '1', 'important');
+            iframe.style.setProperty('pointer-events', 'auto', 'important');
             if (mobile) {
                 iframe.style.setProperty('display', 'block', 'important');
                 iframe.style.setProperty('inset', '0px', 'important');
                 iframe.style.setProperty('width', '100vw', 'important');
-                iframe.style.setProperty('height', '100vh', 'important');
+                iframe.style.setProperty('height', '100dvh', 'important');
                 iframe.style.setProperty('max-width', '100vw', 'important');
-                iframe.style.setProperty('max-height', '100vh', 'important');
+                iframe.style.setProperty('max-height', '100dvh', 'important');
+                iframe.style.setProperty('min-width', '100vw', 'important');
+                iframe.style.setProperty('min-height', '100dvh', 'important');
+                iframe.style.setProperty('border-radius', '0px', 'important');
                 iframe.style.removeProperty('right');
                 iframe.style.removeProperty('bottom');
+                iframe.style.removeProperty('top');
+                iframe.style.removeProperty('left');
+                iframe.style.setProperty('transform', 'none', 'important');
             } else {
                 iframe.style.setProperty('display', 'flex', 'important');
                 iframe.style.setProperty('right', '1rem', 'important');
@@ -602,6 +609,12 @@
                 iframe.style.removeProperty('height');
                 iframe.style.removeProperty('max-width');
                 iframe.style.removeProperty('max-height');
+                iframe.style.removeProperty('min-width');
+                iframe.style.removeProperty('min-height');
+                iframe.style.removeProperty('top');
+                iframe.style.removeProperty('left');
+                iframe.style.removeProperty('transform');
+                iframe.style.removeProperty('border-radius');
             }
         };
 
@@ -609,6 +622,7 @@
             iframe.style.setProperty('display', 'none', 'important');
             iframe.style.setProperty('visibility', 'hidden', 'important');
             iframe.style.setProperty('opacity', '0', 'important');
+            iframe.style.setProperty('pointer-events', 'none', 'important');
         };
 
         // クリックイベントを設定（クローンせずに直接）

--- a/js/main.js
+++ b/js/main.js
@@ -587,12 +587,17 @@ function stabilizeDifyChatWidget() {
             if (isMobileViewport()) {
                 windowEl.style.removeProperty('right');
                 windowEl.style.removeProperty('bottom');
+                windowEl.style.removeProperty('top');
+                windowEl.style.removeProperty('left');
                 windowEl.style.setProperty('inset', '0px', 'important');
                 windowEl.style.setProperty('width', '100vw', 'important');
-                windowEl.style.setProperty('height', '100vh', 'important');
+                windowEl.style.setProperty('height', '100dvh', 'important');
                 windowEl.style.setProperty('max-width', '100vw', 'important');
-                windowEl.style.setProperty('max-height', '100vh', 'important');
+                windowEl.style.setProperty('max-height', '100dvh', 'important');
+                windowEl.style.setProperty('min-width', '100vw', 'important');
+                windowEl.style.setProperty('min-height', '100dvh', 'important');
                 windowEl.style.setProperty('border-radius', '0px', 'important');
+                windowEl.style.setProperty('transform', 'none', 'important');
             } else {
                 windowEl.style.setProperty('right', bubbleRight, 'important');
                 windowEl.style.setProperty('bottom', windowBottom, 'important');
@@ -601,9 +606,12 @@ function stabilizeDifyChatWidget() {
                 windowEl.style.removeProperty('width');
                 windowEl.style.removeProperty('height');
                 windowEl.style.removeProperty('max-width');
+                windowEl.style.removeProperty('min-width');
+                windowEl.style.removeProperty('min-height');
                 windowEl.style.removeProperty('border-radius');
                 windowEl.style.removeProperty('top');
                 windowEl.style.removeProperty('left');
+                windowEl.style.removeProperty('transform');
             }
 
             const visible = isElementVisible(windowEl);


### PR DESCRIPTION
## Summary
- adjust the Dify chat stabilizer so the window uses a full-screen layout on small screens while preserving desktop positioning
- update the manual chat toggle helper to apply responsive styles and keep the iframe interactive after orientation changes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e6f9af12648323ba893627c7105e6d