### PR TITLE
Handle off-screen chat iframe visibility during close animation

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -553,6 +553,20 @@ function stabilizeDifyChatWidget() {
         if (!element) return false;
         const rect = element.getBoundingClientRect();
         if (rect.width <= 0 || rect.height <= 0) return false;
+
+        const viewportWidth = window.innerWidth || document.documentElement?.clientWidth || 0;
+        const viewportHeight = window.innerHeight || document.documentElement?.clientHeight || 0;
+        if (viewportWidth > 0 && viewportHeight > 0) {
+            const tolerance = 2;
+            const completelyAbove = rect.bottom <= -tolerance;
+            const completelyBelow = rect.top >= viewportHeight + tolerance;
+            const completelyLeft = rect.right <= -tolerance;
+            const completelyRight = rect.left >= viewportWidth + tolerance;
+            if (completelyAbove || completelyBelow || completelyLeft || completelyRight) {
+                return false;
+            }
+        }
+
         const style = window.getComputedStyle(element);
         if (style.display === 'none' || style.visibility === 'hidden') return false;
         const opacity = parseFloat(style.opacity || '1');


### PR DESCRIPTION
## Summary
- treat chat iframe as hidden once it moves fully outside the viewport
- allow Dify's close animation to complete without being reset by the sync watcher
- allow a small viewport tolerance when checking iframe visibility so minor safe-area offsets don't hide the window erroneously

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e71a0c32348323af902d383e287036