### PR TITLE
Adjust Dify chat widget pointer-events handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -583,7 +583,6 @@
             'z-index',
             'visibility',
             'opacity',
-            'pointer-events',
             'display',
             'inset',
             'width',
@@ -643,6 +642,7 @@
             for (const property of propertiesToClear) {
                 iframe.style.removeProperty(property);
             }
+            iframe.style.setProperty('pointer-events', 'none', 'important');
         }
 
         const toggleIcons = (buttonEl, isOpen) => {

--- a/js/main.js
+++ b/js/main.js
@@ -692,7 +692,6 @@ function stabilizeDifyChatWidget() {
             windowEl.removeAttribute('aria-hidden');
             windowEl.style.setProperty('position', 'fixed', 'important');
             windowEl.style.setProperty('z-index', '2147483649', 'important');
-            windowEl.style.setProperty('pointer-events', 'auto', 'important');
 
             ensureWindowHasDimensions(windowEl);
 
@@ -725,6 +724,13 @@ function stabilizeDifyChatWidget() {
             if (visible && !windowShouldStayOpen) {
                 windowShouldStayOpen = true;
             }
+
+            const shouldEnablePointerEvents = windowShouldStayOpen;
+            windowEl.style.setProperty(
+                'pointer-events',
+                shouldEnablePointerEvents ? 'auto' : 'none',
+                'important'
+            );
 
             if (windowShouldStayOpen) {
 


### PR DESCRIPTION
## Summary
- prevent the fixDifyButtonClick helper from clearing pointer-events when the iframe closes so the bubble remains clickable
- update stabilizeDifyChatWidget to set pointer-events to auto only when the chat window should stay open and force none otherwise

## Testing
- not run (manual verification required in a live environment)


------
https://chatgpt.com/codex/tasks/task_e_68e7349b8898832397f1ba8fe5f7269e