### PR TITLE
Fix Dify chat bubble timing and guard against premature close

### DIFF
--- a/index.html
+++ b/index.html
@@ -678,12 +678,26 @@
             return rect.width > 0 && rect.height > 0;
         };
 
+        let closeGuardUntil = 0;
+
         const syncStylesWithState = (buttonEl, options = {}) => {
-            const { delay = true } = options;
+            const { delay = true, guardAgainstImmediateClose = false } = options;
 
             const performSync = () => {
                 const isOpen = isIframeVisible();
+                const now = typeof performance !== 'undefined' && performance.now ? performance.now() : Date.now();
+
+                if (!isOpen && guardAgainstImmediateClose && now < closeGuardUntil) {
+                    if (typeof window.requestAnimationFrame === 'function') {
+                        window.requestAnimationFrame(performSync);
+                    } else {
+                        window.setTimeout(performSync, 50);
+                    }
+                    return;
+                }
+
                 if (isOpen) {
+                    closeGuardUntil = 0;
                     applyOpenStyles();
                 } else {
                     applyClosedStyles();
@@ -707,8 +721,10 @@
         // クリックイベントを設定（クローンせずに直接）
         button.addEventListener('click', function() {
             console.log('[Dify Fix] Button clicked!');
-            syncStylesWithState(this, { delay: true });
-        }, true); // capture phase で確実に捕捉
+            const now = typeof performance !== 'undefined' && performance.now ? performance.now() : Date.now();
+            closeGuardUntil = now + 500;
+            syncStylesWithState(this, { delay: true, guardAgainstImmediateClose: true });
+        });
 
         // 初期状態の同期
         syncStylesWithState(button, { delay: false });


### PR DESCRIPTION
## Summary
- update the Dify chat bubble click handler to run in the bubbling phase so style sync happens after the default behaviour
- add a guard that delays applying closed styles until the iframe reports visible to keep the chat window open

## Testing
- Manual: Verified `[Dify Fix] ✅ Chat opened` logs appear after clicking the chat bubble and the Dify window stays visible

------
https://chatgpt.com/codex/tasks/task_e_68e737dc01fc8323b5a117e4d130b9fb