### PR TITLE
Refine Dify iframe visibility overrides

### DIFF
--- a/index.html
+++ b/index.html
@@ -578,26 +578,6 @@
 
         const isMobileViewport = () => window.matchMedia && window.matchMedia('(max-width: 768px)').matches;
 
-        const propertiesToClear = [
-            'position',
-            'z-index',
-            'visibility',
-            'opacity',
-            'display',
-            'inset',
-            'width',
-            'height',
-            'max-width',
-            'max-height',
-            'min-width',
-            'min-height',
-            'border-radius',
-            'transform',
-            'right',
-            'bottom',
-            'left',
-            'top'
-        ];
         function applyOpenStyles() {
             const mobile = isMobileViewport();
             iframe.style.setProperty('position', 'fixed', 'important');
@@ -626,12 +606,6 @@
                 iframe.style.setProperty('right', '1rem', 'important');
                 iframe.style.setProperty('bottom', '1rem', 'important');
                 iframe.style.removeProperty('inset');
-                iframe.style.removeProperty('width');
-                iframe.style.removeProperty('height');
-                iframe.style.removeProperty('max-width');
-                iframe.style.removeProperty('max-height');
-                iframe.style.removeProperty('min-width');
-                iframe.style.removeProperty('min-height');
                 iframe.style.removeProperty('top');
                 iframe.style.removeProperty('left');
                 iframe.style.removeProperty('border-radius');
@@ -639,10 +613,11 @@
         }
 
         function applyClosedStyles() {
-            for (const property of propertiesToClear) {
-                iframe.style.removeProperty(property);
-            }
+            iframe.style.setProperty('display', 'none', 'important');
+            iframe.style.setProperty('visibility', 'hidden', 'important');
+            iframe.style.setProperty('opacity', '0', 'important');
             iframe.style.setProperty('pointer-events', 'none', 'important');
+            iframe.style.setProperty('transform', 'none', 'important');
         }
 
         const toggleIcons = (buttonEl, isOpen) => {


### PR DESCRIPTION
## Summary
- ensure the Dify helper hides the iframe via explicit hidden-state styles instead of stripping inline sizing
- restore the visible state styles when reopening so the embed retains its display and pointer interaction

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68e73d893a24832390accc7ef2f5f5e6