### PR TITLE
Refactor Dify embed proxy to rewrite relative asset URLs

### DIFF
--- a/functions/api/dify-embed-proxy.ts
+++ b/functions/api/dify-embed-proxy.ts
@@ -1,5 +1,9 @@
+import { normalizeBaseUrl, rewriteEmbedScript } from "../dify/embed-shared";
+
 export const onRequestGet = async ({ env }) => {
-  const baseUrl = env.DIFY_CHATBOT_BASE_URL || "https://dexakyo.akyodex.com";
+  const baseUrl = normalizeBaseUrl(
+    (env.DIFY_CHATBOT_BASE_URL || "https://dexakyo.akyodex.com").trim()
+  );
   const scriptUrl = `${baseUrl}/embed.min.js`;
   
   try {
@@ -16,8 +20,9 @@ export const onRequestGet = async ({ env }) => {
     }
     
     const script = await response.text();
-    
-    return new Response(script, {
+    const rewritten = rewriteEmbedScript(script, baseUrl);
+
+    return new Response(rewritten, {
       status: 200,
       headers: {
         'Content-Type': 'application/javascript; charset=UTF-8',


### PR DESCRIPTION
## Summary
- expose shared helpers for normalizing the chatbot base URL and rewriting relative asset paths inside embed.min.js
- reuse the shared rewrite logic in the API embed proxy so the proxied script serves absolute URLs based on DIFY_CHATBOT_BASE_URL

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7415b03548323a897dadeb262666f