### PR TITLE
Strip Cloudflare beacon URL from proxied Dify embed script

### DIFF
--- a/functions/dify/embed-shared.ts
+++ b/functions/dify/embed-shared.ts
@@ -16,10 +16,13 @@ export const DEFAULT_HEADERS = {
 
 export const normalizeBaseUrl = (baseUrl: string) => baseUrl.replace(/\/+$/, "");
 
+const CLOUDFLARE_BEACON_PATTERN =
+  /(["'`])https:\/\/static\.cloudflareinsights\.com\/beacon\.min\.js[^"'`]*\1/g;
+
 export const rewriteEmbedScript = (scriptContent: string, baseUrl: string) => {
   const normalizedBaseUrl = normalizeBaseUrl(baseUrl);
 
-  return scriptContent.replace(
+  const absolutized = scriptContent.replace(
     RELATIVE_PATH_PATTERN,
     (match, quote: string, path: string) => {
       try {
@@ -30,6 +33,10 @@ export const rewriteEmbedScript = (scriptContent: string, baseUrl: string) => {
       }
     }
   );
+
+  return absolutized.replace(CLOUDFLARE_BEACON_PATTERN, (_match, quote: string) => {
+    return `${quote}about:blank${quote}`;
+  });
 };
 
 export const onRequestGet: PagesFunction<Env> = async ({ env }) => {


### PR DESCRIPTION
## Summary
- update the Dify embed rewriting helper to blank out the Cloudflare Insights beacon URL
- keep the relative-path rewriting behaviour so the chat script continues to load assets correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e742c9dd288323b4f90096db4852f0