### PR TITLE
Stub Cloudflare beacon in Dify embed proxy

### DIFF
--- a/functions/dify/embed-shared.ts
+++ b/functions/dify/embed-shared.ts
@@ -24,6 +24,10 @@ const CLOUDFLARE_BEACON_PATTERN =
 const CLOUDFLARE_BEACON_LOOSE_PATTERN =
   /https?:\/\/static\.cloudflareinsights\.com\/beacon\.min\.js[^\s"'`)]*/g;
 
+const CLOUDFLARE_BEACON_STUB = `data:text/javascript;charset=utf-8,${encodeURIComponent(
+  "window.dispatchEvent(new Event('akyo:difyCfBeaconStubLoaded'));"
+)}`;
+
 
 export const rewriteEmbedScript = (scriptContent: string, baseUrl: string) => {
   const normalizedBaseUrl = normalizeBaseUrl(baseUrl);
@@ -43,12 +47,12 @@ export const rewriteEmbedScript = (scriptContent: string, baseUrl: string) => {
 
   const withoutStrictBeacon = absolutized.replace(
     CLOUDFLARE_BEACON_PATTERN,
-    (_match, quote: string) => `${quote}about:blank${quote}`
+    (_match, quote: string) => `${quote}${CLOUDFLARE_BEACON_STUB}${quote}`
   );
 
   return withoutStrictBeacon.replace(
     CLOUDFLARE_BEACON_LOOSE_PATTERN,
-    "about:blank"
+    CLOUDFLARE_BEACON_STUB
   );
 
 };


### PR DESCRIPTION
## Summary
- replace the Cloudflare beacon URL in the proxied Dify embed script with an inline data URI stub
- ensure the stub fires a load event so the widget can finish bootstrapping even if analytics requests are blocked

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e74adb21e48323916a82b63edb4361