### PR TITLE
Add resilience to Dify chatbot script loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -479,6 +479,81 @@
         console.info(`[Dify] Chatbot disabled: ${reason}`);
     };
 
+    const toAbsoluteUrl = (value) => {
+        try {
+            return new URL(value, window.location.origin).toString();
+        } catch (error) {
+            console.warn('[Dify] Failed to resolve URL, using raw value', value, error);
+            return value;
+        }
+    };
+
+    const loadScriptTag = (url, attemptLabel) => {
+        const timeoutMs = 15000;
+
+        return new Promise((resolve, reject) => {
+            const script = document.createElement('script');
+            script.src = url;
+            script.crossOrigin = 'anonymous';
+            script.dataset.akyoDifyEmbed = attemptLabel || '1';
+
+            const timeoutId = window.setTimeout(() => {
+                script.remove();
+                reject(new Error('timeout'));
+            }, timeoutMs);
+
+            script.addEventListener('load', () => {
+                window.clearTimeout(timeoutId);
+                resolve(true);
+            });
+
+            script.addEventListener('error', (event) => {
+                window.clearTimeout(timeoutId);
+                script.remove();
+                reject(event?.error || new Error('network-error'));
+            });
+
+            document.head.appendChild(script);
+        });
+    };
+
+    const loadScriptInline = async (url, attemptLabel) => {
+        const response = await fetch(url, {
+            credentials: 'omit',
+            cache: 'no-store',
+        });
+
+        if (!response.ok) {
+            throw new Error(`inline-fetch-${response.status}`);
+        }
+
+        const source = await response.text();
+        const inlineScript = document.createElement('script');
+        inlineScript.dataset.akyoDifyEmbed = attemptLabel || 'inline';
+        inlineScript.textContent = source;
+        document.head.appendChild(inlineScript);
+        return true;
+    };
+
+    const attemptScriptLoad = async (candidates) => {
+        for (const candidate of candidates) {
+            const { url, mode, label } = candidate;
+            try {
+                if (mode === 'inline') {
+                    await loadScriptInline(url, label);
+                } else {
+                    await loadScriptTag(url, label);
+                }
+                console.log(`[Dify] ✅ Script loaded (${label || url})`);
+                return true;
+            } catch (error) {
+                console.warn(`[Dify] ⚠️ Script load attempt failed (${label || url})`, error);
+            }
+        }
+
+        return false;
+    };
+
     const bootstrap = async () => {
         window.__akyoDifyEmbedBootstrapPending = true;
 
@@ -526,20 +601,45 @@
 
             console.log('[Dify] Config set');
 
-            const script = document.createElement('script');
-            script.src = scriptUrl || `${normalizedBaseUrl}/embed.min.js`;
-            script.crossOrigin = 'anonymous';
-            script.dataset.akyoDifyEmbed = '1';
-            
-            script.addEventListener('load', () => {
-                console.log('[Dify] ✅ Script loaded');
-            });
-            
-            script.addEventListener('error', (event) => {
-                console.error('[Dify] ❌ Script load error:', event);
-            });
-            
-            document.head.appendChild(script);
+            const scriptCandidates = [];
+            const seenUrls = new Set();
+            const registerCandidate = (url, mode, label) => {
+                if (!url) {
+                    return;
+                }
+                const key = `${mode}:${url}`;
+                if (seenUrls.has(key)) {
+                    return;
+                }
+                seenUrls.add(key);
+                scriptCandidates.push({ url, mode, label });
+            };
+
+            if (scriptUrl) {
+                registerCandidate(toAbsoluteUrl(scriptUrl), 'tag', 'config-script');
+            }
+
+            registerCandidate(`${normalizedBaseUrl}/embed.min.js`, 'tag', 'direct-base');
+
+            if (normalizedBaseUrl.startsWith('https://')) {
+                const httpFallback = `http://${normalizedBaseUrl.slice('https://'.length)}`;
+                registerCandidate(`${httpFallback}/embed.min.js`, 'tag', 'http-fallback');
+            } else if (normalizedBaseUrl.startsWith('http://')) {
+                const httpsFallback = `https://${normalizedBaseUrl.slice('http://'.length)}`;
+                registerCandidate(`${httpsFallback}/embed.min.js`, 'tag', 'https-fallback');
+            }
+
+            if (scriptUrl && scriptUrl.startsWith('/')) {
+                registerCandidate(toAbsoluteUrl(scriptUrl), 'inline', 'inline-proxy');
+            }
+
+            const loaded = await attemptScriptLoad(scriptCandidates);
+
+            if (!loaded) {
+                markDisabled('script-load-failed');
+                return;
+            }
+
             window.__akyoDifyEmbedBootstrapPending = false;
         } catch (error) {
             console.error('[Dify] Bootstrap error:', error);


### PR DESCRIPTION
## Summary
- add reusable helpers to resolve URLs and load the Dify embed script with timeout handling
- attempt multiple script sources, including inline fetch fallback, to avoid blockers that prevent the chatbot from appearing

## Testing
- not run (static site change)


------
https://chatgpt.com/codex/tasks/task_e_68e74fb230008323b2c64a3f365fc625