### PR TITLE
perf: Apply React Best Practices for localStorage and Set lookups

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9182,7 +9182,6 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -9711,7 +9710,6 @@
       "integrity": "sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.56.1"
       },
@@ -11508,7 +11506,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.25.tgz",
       "integrity": "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -11529,7 +11526,6 @@
       "integrity": "sha512-p/jUvulfgU7oKtj6Xpk8cA2Y1xKTtICGpJYeJXz2YVO2UcvjQgeRMLDGfDeqeRW2Ta+0QNFwcc8X3GH8SxZz6w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -11590,7 +11586,6 @@
       "integrity": "sha512-lJi3PfxVmo0AkEY93ecfN+r8SofEqZNGByvHAI3GBLrvt1Cw6H5k1IM02nSzu0RfUafr2EvFSw0wAsZgubNplQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.47.0",
         "@typescript-eslint/types": "8.47.0",
@@ -12145,7 +12140,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -13519,7 +13513,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -13693,7 +13686,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -17337,7 +17329,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -17347,7 +17338,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -18496,7 +18486,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -18544,7 +18533,6 @@
       "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -18786,7 +18774,6 @@
       "integrity": "sha512-Om5ns0Lyx/LKtYI04IV0bjIrkBgoFNg0p6urzr2asekJlfP18RqFzyqMFZKf0i9Gnjtz/JfAS/Ol6tjCe5JJsQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },
@@ -18806,7 +18793,6 @@
       "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.50.0.tgz",
       "integrity": "sha512-+nuZuHZxDdKmAyXOSrHlciGshCoAPiy5dM+t6mEohWm7HpXvTHmWQGUf/na9jjWlWJHCJYOWzkA1P5HBJqrIEA==",
       "license": "MIT OR Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cloudflare/kv-asset-handler": "0.4.0",
         "@cloudflare/unenv-preset": "2.7.11",

--- a/src/components/akyo-card.tsx
+++ b/src/components/akyo-card.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { getCategoryColor } from '@/lib/akyo-data-helpers';
 import { generateBlurDataURL } from '@/lib/blur-data-url';
 import { buildAvatarImageUrl } from '@/lib/vrchat-utils';
 import type { AkyoData } from '@/types/akyo';
@@ -9,47 +10,6 @@ interface AkyoCardProps {
   akyo: AkyoData;
   onToggleFavorite?: (id: string) => void;
   onShowDetail?: (akyo: AkyoData) => void;
-}
-
-// カテゴリに対応する色を取得（元の実装のgetAttributeColorを再現）
-function getCategoryColor(category: string): string {
-  const colorMap: Record<string, string> = {
-    チョコミント: '#00bfa5',
-    動物: '#ff6f61',
-    きつね: '#ff9800',
-    おばけ: '#9c27b0',
-    人類: '#2196f3',
-    ギミック: '#4caf50',
-    特殊: '#e91e63',
-    ネコ: '#795548',
-    イヌ: '#607d8b',
-    うさぎ: '#ff4081',
-    ドラゴン: '#673ab7',
-    ロボット: '#757575',
-    食べ物: '#ffc107',
-    植物: '#8bc34a',
-    宇宙: '#3f51b5',
-    和風: '#d32f2f',
-    洋風: '#1976d2',
-    ファンタジー: '#ab47bc',
-    SF: '#00acc1',
-    ホラー: '#424242',
-    かわいい: '#ec407a',
-    クール: '#5c6bc0',
-    シンプル: '#78909c',
-  };
-
-  // 最初にマッチする属性の色を返す
-  for (const [key, color] of Object.entries(colorMap)) {
-    if (category && category.includes(key)) {
-      return color;
-    }
-  }
-
-  // デフォルト色
-  const defaultColors = ['#667eea', '#764ba2', '#f093fb', '#f5576c', '#4facfe'];
-
-  return defaultColors[Math.floor(Math.random() * defaultColors.length)];
 }
 
 export function AkyoCard({ akyo, onToggleFavorite, onShowDetail }: AkyoCardProps) {
@@ -100,6 +60,7 @@ export function AkyoCard({ akyo, onToggleFavorite, onShowDetail }: AkyoCardProps
 
         {/* お気に入りボタン */}
         <button
+          type="button"
           onClick={handleFavoriteClick}
           className="favorite-btn absolute top-2 right-2 z-10"
           aria-label={akyo.isFavorite ? 'お気に入り解除' : 'お気に入り登録'}
@@ -114,6 +75,7 @@ export function AkyoCard({ akyo, onToggleFavorite, onShowDetail }: AkyoCardProps
         <div className="flex items-center justify-between mb-1">
           <span className="text-sm font-bold text-gray-500">#{akyo.id}</span>
           <button
+            type="button"
             onClick={handleDownloadClick}
             className="reference-sheet-button"
             title="三面図をダウンロード"
@@ -177,6 +139,7 @@ export function AkyoCard({ akyo, onToggleFavorite, onShowDetail }: AkyoCardProps
 
         {/* くわしく見るボタン */}
         <button
+          type="button"
           onClick={handleCardClick}
           className="detail-button w-full flex items-center justify-center gap-2"
         >

--- a/src/components/akyo-detail-modal.tsx
+++ b/src/components/akyo-detail-modal.tsx
@@ -14,6 +14,7 @@
  * - Action buttons (favorite + VRChat link)
  */
 
+import { getCategoryColor } from '@/lib/akyo-data-helpers';
 import { buildAvatarImageUrl } from '@/lib/vrchat-utils';
 import type { AkyoData } from '@/types/akyo';
 import Image from 'next/image';
@@ -25,43 +26,6 @@ interface AkyoDetailModalProps {
   isOpen: boolean;
   onClose: () => void;
   onToggleFavorite?: (id: string) => void;
-}
-
-// カテゴリ色マッピング (元の実装と完全一致)
-function getCategoryColor(category: string): string {
-  const colorMap: Record<string, string> = {
-    チョコミント: '#00bfa5',
-    動物: '#ff6f61',
-    きつね: '#ff9800',
-    おばけ: '#9c27b0',
-    人類: '#2196f3',
-    ギミック: '#4caf50',
-    特殊: '#e91e63',
-    ネコ: '#795548',
-    イヌ: '#607d8b',
-    うさぎ: '#ff4081',
-    ドラゴン: '#673ab7',
-    ロボット: '#757575',
-    食べ物: '#ffc107',
-    植物: '#8bc34a',
-    宇宙: '#3f51b5',
-    和風: '#d32f2f',
-    洋風: '#1976d2',
-    ファンタジー: '#ab47bc',
-    SF: '#00acc1',
-    ホラー: '#424242',
-    かわいい: '#ec407a',
-    クール: '#5c6bc0',
-    シンプル: '#78909c',
-  };
-
-  for (const [key, color] of Object.entries(colorMap)) {
-    if (category && category.includes(key)) {
-      return color;
-    }
-  }
-
-  return '#667eea';
 }
 
 export function AkyoDetailModal({ akyo, isOpen, onClose, onToggleFavorite }: AkyoDetailModalProps) {
@@ -336,6 +300,7 @@ export function AkyoDetailModal({ akyo, isOpen, onClose, onToggleFavorite }: Aky
           >
             {/* Close Button */}
             <button
+              type="button"
               onClick={onClose}
               className="absolute top-4 right-4 w-14 h-14 rounded-full z-[60] flex items-center justify-center transition-all duration-300 hover:scale-110"
               style={{
@@ -535,6 +500,7 @@ export function AkyoDetailModal({ akyo, isOpen, onClose, onToggleFavorite }: Aky
                 <div className="flex gap-3 pt-4 border-t">
                   {/* Favorite Button - ピンク色 */}
                   <button
+                    type="button"
                     onClick={handleFavoriteClick}
                     className={`flex-1 py-3 rounded-lg font-medium transition-colors flex items-center justify-center gap-2 ${
                       localAkyo.isFavorite
@@ -557,6 +523,7 @@ export function AkyoDetailModal({ akyo, isOpen, onClose, onToggleFavorite }: Aky
                   {/* VRChat Button - Orange Gradient (not purple!) */}
                   {localAkyo.avatarUrl && (
                     <button
+                      type="button"
                       onClick={handleVRChatOpen}
                       className="flex-1 py-3 rounded-lg font-medium transition-opacity flex items-center justify-center gap-2"
                       style={{

--- a/src/components/akyo-list.tsx
+++ b/src/components/akyo-list.tsx
@@ -2,6 +2,7 @@
 
 import Image from 'next/image';
 import type { AkyoData } from '@/types/akyo';
+import { getCategoryColor } from '@/lib/akyo-data-helpers';
 import { generateBlurDataURL } from '@/lib/blur-data-url';
 import { buildAvatarImageUrl } from '@/lib/vrchat-utils';
 
@@ -9,51 +10,6 @@ interface AkyoListProps {
   data: AkyoData[];
   onToggleFavorite?: (id: string) => void;
   onShowDetail?: (akyo: AkyoData) => void;
-}
-
-// カテゴリに対応する色を取得
-function getCategoryColor(category: string): string {
-  const colorMap: Record<string, string> = {
-    チョコミント: '#00bfa5',
-    動物: '#ff6f61',
-    きつね: '#ff9800',
-    おばけ: '#9c27b0',
-    人類: '#2196f3',
-    ギミック: '#4caf50',
-    特殊: '#e91e63',
-    ネコ: '#795548',
-    イヌ: '#607d8b',
-    うさぎ: '#ff4081',
-    ドラゴン: '#673ab7',
-    ロボット: '#757575',
-    食べ物: '#ffc107',
-    植物: '#8bc34a',
-    宇宙: '#3f51b5',
-    和風: '#d32f2f',
-    洋風: '#1976d2',
-    ファンタジー: '#ab47bc',
-    SF: '#00acc1',
-    ホラー: '#424242',
-    かわいい: '#ec407a',
-    クール: '#5c6bc0',
-    シンプル: '#78909c',
-  };
-
-  for (const [key, color] of Object.entries(colorMap)) {
-    if (category && category.includes(key)) {
-      return color;
-    }
-  }
-
-  const defaultColors = [
-    '#667eea',
-    '#764ba2',
-    '#f093fb',
-    '#f5576c',
-    '#4facfe',
-  ];
-  
-  return defaultColors[Math.floor(Math.random() * defaultColors.length)];
 }
 
 export function AkyoList({ data, onToggleFavorite, onShowDetail }: AkyoListProps) {
@@ -157,6 +113,7 @@ export function AkyoList({ data, onToggleFavorite, onShowDetail }: AkyoListProps
                     <div className="flex items-center justify-center gap-1">
                       {/* お気に入りボタン */}
                       <button
+                        type="button"
                         onClick={(e) => handleFavoriteClick(e, akyo.id)}
                         className="list-action-btn"
                         aria-label={akyo.isFavorite ? 'お気に入り解除' : 'お気に入り登録'}
@@ -168,6 +125,7 @@ export function AkyoList({ data, onToggleFavorite, onShowDetail }: AkyoListProps
 
                       {/* 詳細ボタン */}
                       <button
+                        type="button"
                         onClick={(e) => handleDetailClick(e, akyo)}
                         className="list-action-btn"
                         aria-label="詳細を見る"

--- a/src/lib/akyo-data-helpers.ts
+++ b/src/lib/akyo-data-helpers.ts
@@ -59,3 +59,66 @@ export function extractAuthors(data: AkyoData[]): string[] {
 export function findAkyoById(data: AkyoData[], id: string): AkyoData | null {
   return data.find((akyo) => akyo.id === id) || null;
 }
+
+/**
+ * カテゴリ名 → 色の定数マッピング
+ */
+const CATEGORY_COLOR_MAP: Record<string, string> = {
+  チョコミント: '#00bfa5',
+  動物: '#ff6f61',
+  きつね: '#ff9800',
+  おばけ: '#9c27b0',
+  人類: '#2196f3',
+  ギミック: '#4caf50',
+  特殊: '#e91e63',
+  ネコ: '#795548',
+  イヌ: '#607d8b',
+  うさぎ: '#ff4081',
+  ドラゴン: '#673ab7',
+  ロボット: '#757575',
+  食べ物: '#ffc107',
+  植物: '#8bc34a',
+  宇宙: '#3f51b5',
+  和風: '#d32f2f',
+  洋風: '#1976d2',
+  ファンタジー: '#ab47bc',
+  SF: '#00acc1',
+  ホラー: '#424242',
+  かわいい: '#ec407a',
+  クール: '#5c6bc0',
+  シンプル: '#78909c',
+};
+
+const DEFAULT_COLORS = ['#667eea', '#764ba2', '#f093fb', '#f5576c', '#4facfe'];
+
+/**
+ * 文字列から決定的なハッシュ値を生成（簡易 djb2）
+ * Math.random() の代わりに使用し、同一カテゴリ名には常に同じ色を返す
+ */
+function hashString(str: string): number {
+  let hash = 5381;
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) + hash) + str.charCodeAt(i);
+    hash |= 0; // 32bit整数に変換
+  }
+  return Math.abs(hash);
+}
+
+/**
+ * カテゴリ名に対応する色を取得
+ *
+ * マッピングに一致するキーワードが含まれていればその色を返し、
+ * 一致しなければカテゴリ名のハッシュからデフォルト色を決定的に選択する。
+ * （Math.random() を使わないため SSR/CSR のハイドレーションミスマッチが起きない）
+ *
+ * @param category - カテゴリ文字列
+ * @returns HEX カラーコード
+ */
+export function getCategoryColor(category: string): string {
+  for (const [key, color] of Object.entries(CATEGORY_COLOR_MAP)) {
+    if (category && category.includes(key)) {
+      return color;
+    }
+  }
+  return DEFAULT_COLORS[hashString(category || '') % DEFAULT_COLORS.length];
+}


### PR DESCRIPTION
## Summary

Vercel の React Best Practices に基づくパフォーマンス最適化と、CodeRabbit レビュー指摘の修正、およびコード品質改善を適用します。

## Changes

### 1. Performance: localStorage キャッシング (Rule 7.5)
- お気に入り情報をメモリ内にキャッシュ
- 頻繁な localStorage 読み込みを回避
- 保存時にキャッシュを先に更新し、セッション内一貫性を確保

### 2. Performance: Set を使用した O(1) ルックアップ (Rule 7.11)
- `Array.includes()` を `Set.has()` に置き換え
- 500+ アイテムでの初期化速度を改善
- `applyFavorites()` ヘルパーで重複ロジックを共通化

### 3. Code Quality: CodeRabbit レビュー指摘対応
- `getFavorites`: `JSON.parse` の結果を `Array.isArray` + 型ガードでバリデーション
  - localStorage に不正データがある場合のランタイムエラーを防止
- `saveFavorites`: 防御的シャローコピーでキャッシュをミューテーションから保護
- `saveFavorites`: キャッシュを先に更新し、`localStorage.setItem` 失敗時もセッション内一貫性を維持
- 全インタラクティブボタンに `type="button"` を追加（意図しないフォーム送信を防止）
  - `akyo-card.tsx`: お気に入り・DL・詳細ボタン
  - `akyo-list.tsx`: お気に入り・詳細ボタン
  - `akyo-detail-modal.tsx`: 閉じる・お気に入り・VRChat ボタン

### 4. Refactor: getCategoryColor の共通化 (DRY)
- `akyo-card.tsx`, `akyo-list.tsx`, `akyo-detail-modal.tsx` に重複定義されていた `getCategoryColor` を `akyo-data-helpers.ts` に一元化
- デフォルト色の選択を `Math.random()` から決定的ハッシュ（djb2）に変更
  - SSR/CSR ハイドレーションミスマッチを防止
  - レンダリング毎の色のちらつきを解消

### 5. Refactor: applyFavorites ヘルパー抽出 (DRY)
- `useEffect` と `refetchWithNewData` で重複していた Set/map パターンを `applyFavorites()` に集約

## Impact

| 改善項目 | Before | After |
|----------|--------|-------|
| favorites lookup | O(n) per item | O(1) per item |
| localStorage reads | 毎回読み込み | 初回のみ |
| JSON.parse 安全性 | 未検証 | バリデーション済み |
| getCategoryColor | 3ファイルに重複 | 1箇所に集約 |
| デフォルト色 | Math.random()（非決定的） | djb2 hash（決定的） |
| localStorage 失敗時 | キャッシュ不整合 | セッション一貫性維持 |
| ボタン type 属性 | 未指定 | 全ボタンに明示 |
| favorites ロジック | 2箇所に重複 | applyFavorites() に集約 |

## Deferred (別PRで対応予定)
- `findAkyoById` の Map ベース O(1) 化（呼び出し元変更が必要なためスコープ外）
- `getCategoryColor` のキーワード優先順序最適化（現行データでは実用上問題なし）
- マルチタブでの `storage` イベント同期（現在要件外）

## Reference

- [Vercel React Best Practices](https://github.com/vercel-labs/agent-skills/tree/main/skills/react-best-practices)
- [Rule 7.5: Cache Storage API Calls](https://github.com/vercel-labs/agent-skills/blob/main/skills/react-best-practices/AGENTS.md#75-cache-storage-api-calls)
- [Rule 7.11: Use Set/Map for O(1) Lookups](https://github.com/vercel-labs/agent-skills/blob/main/skills/react-best-practices/AGENTS.md#711-use-setmap-for-o1-lookups)

Co-Authored-By: Warp <agent@warp.dev>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * お気に入り処理を集中化・高速化し、メモリ内キャッシュと安定した照合で読み込みと更新を改善しました。
  * 内部データの防御的コピーと検証を追加して信頼性を向上しました。

* **New Features**
  * カテゴリ表示の色付けロジックを共通化・安定化し、表示の一貫性を強化しました。

* **Bug Fixes**
  * ボタンの既定動作を明確化して、意図しないフォーム送信を防止しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->