### PR TITLE
fix(sw): return cached assets and stop fake 404 fallback

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -264,11 +264,12 @@ async function handleStaticAssets(event, request) {
 
     if (networkResponse && networkResponse.ok) {
       await cache.put(request, networkResponse.clone());
+      return networkResponse;
     }
 
-    return networkResponse;
+    throw new Error(`[SW] Non-OK static asset response: ${networkResponse.status} ${networkResponse.statusText}`);
   } catch (error) {
-    console.log('[SW] Network failed for static asset:', error.message);
+    console.log('[SW] Network failed for static asset:', error?.message || error);
     throw error;
   }
 }
@@ -330,11 +331,12 @@ async function handleDefaultRequest(event, request) {
 
     if (networkResponse && networkResponse.ok) {
       await cache.put(request, networkResponse.clone());
+      return networkResponse;
     }
 
-    return networkResponse;
+    throw new Error(`[SW] Non-OK default asset response: ${networkResponse.status} ${networkResponse.statusText}`);
   } catch (error) {
-    console.log('[SW] Network failed for default request:', error.message);
+    console.log('[SW] Network failed for default request:', error?.message || error);
     throw error;
   }
 }


### PR DESCRIPTION
### Motivation

- Prevent the service worker from masking real network failures with empty 404 responses for static/assets.
- Ensure that when a cached response exists it is always returned immediately for best UX while still performing a background update.
- Let browser-native failure handling occur when both cache and network fail instead of returning synthetic responses.
- Invalidate old caches so the changed behavior does not keep using prior (incorrect) cache entries.

### Description

- Bumped cache version by changing `CACHE_VERSION` to `akyodex-nextjs-v5` to force invalidation of old caches.
- Updated `/_next/static/` handling to call `event.respondWith(handleStaticAssets(event, request))` and changed `handleStaticAssets` signature to `handleStaticAssets(event, request)`.
- When cache exists `handleStaticAssets` now always returns the cached response and schedules `event.waitUntil(updateCacheInBackground(...))` for background refresh, and only writes to cache when network response is `ok`.
- `handleStaticAssets` and `handleDefaultRequest` no longer return synthetic `new Response('', { status: 404 })` on failures and instead rethrow the fetch error so the browser's standard failure behavior applies.

### Testing

- Ran `node --check public/sw.js` and it completed without syntax errors.
- The service worker code was sanity-checked by static inspection to verify `/_next/static/` and other cache-first flows now return cached responses with background updates and rethrow on network failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dce06e7ec8323b9d029f1db36c593)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * ネットワークや不正な応答時のエラーハンドリングを強化し、問題発生時に詳細なエラー情報を記録して明確に失敗を報告します。

* **Chores**
  * キャッシュのバージョンを更新し、キャッシュ処理を改善してパフォーマンスを向上。
  * キャッシュのバックグラウンド更新を導入し、表示中のコンテンツを迅速に提供しつつ最新化します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->