### PR TITLE
Service worker: make script/style requests Network First and bump cache version

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -217,7 +217,7 @@ async function handleScriptStyleRequest(request) {
   const cache = await caches.open(CACHE_NAME);
 
   try {
-    const networkResponse = await fetch(request);
+    const networkResponse = await fetch(request, { cache: 'no-cache' });
 
     if (networkResponse && networkResponse.ok) {
       await cache.put(request, networkResponse.clone());


### PR DESCRIPTION
### Motivation
- Improve offline/online behavior so JS/CSS are fetched fresh instead of being unconditionally served Cache First under `/_next/static/`.
- Ensure non-script static assets (images/fonts) keep the existing immutable `/_next/static/` Cache First behavior.
- Invalidate old caches after the behavior change by updating the cache version.

### Description
- Bumped `CACHE_VERSION` from `akyodex-nextjs-v7` to `akyodex-nextjs-v8` to invalidate previous caches.
- Reordered fetch routing in `public/sw.js` to check `request.destination === 'script' || request.destination === 'style'` before `/_next/static/` and route those requests to a new handler.
- Added `handleScriptStyleRequest(request)` which implements Network First with offline cache fallback: it attempts `fetch(request)` first, writes to cache only when `response.ok`, falls back to `cache.match(request)` only on network exceptions, and rethrows when no cached response exists.
- Left `handleStaticAssets` intact so non-script/style assets under `/_next/static/` (images, fonts, etc.) remain Cache First.

### Testing
- Validated the modified service worker syntax with `node --check public/sw.js`, which completed successfully. 
- Confirmed the service worker file loads and the new handler is present by inspecting `public/sw.js` lines for the added routing and `handleScriptStyleRequest` function.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ded917da083238607955a847661de)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * スクリプトとスタイルに対するネットワークファースト キャッシング戦略を実装。ネットワーク接続時は最新版を取得し、オフライン時はキャッシュを利用することでより堅牢なオフラインサポートを提供します。

* **チョア**
  * キャッシュバージョンを更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->