### PR TITLE
feat: preserve add-tab draft on transient errors

### DIFF
--- a/src/components/admin/admin-tabs.tsx
+++ b/src/components/admin/admin-tabs.tsx
@@ -3,6 +3,7 @@
 import { IconEdit, IconPlusCircle, IconTools } from '@/components/icons';
 import { useState } from 'react';
 import { AddTab } from './tabs/add-tab';
+import { ADD_TAB_DRAFT_KEY } from './draft-keys';
 import { EditTab } from './tabs/edit-tab';
 import { ToolsTab } from './tabs/tools-tab';
 
@@ -24,6 +25,13 @@ type TabType = 'add' | 'edit' | 'tools';
 export function AdminTabs({ userRole, attributes, creators, akyoData }: AdminTabsProps) {
   const [activeTab, setActiveTab] = useState<TabType>('add');
 
+  const handleTabChange = (nextTab: TabType) => {
+    if (activeTab === 'add' && nextTab !== 'add' && typeof window !== 'undefined') {
+      sessionStorage.removeItem(ADD_TAB_DRAFT_KEY);
+    }
+    setActiveTab(nextTab);
+  };
+
   const handleDataChange = () => {
     // For now, just show a message that page needs refresh
     // In production, this would trigger a router refresh or data revalidation
@@ -36,7 +44,7 @@ export function AdminTabs({ userRole, attributes, creators, akyoData }: AdminTab
       <div className="bg-white rounded-xl shadow-lg mb-6">
         <div className="flex border-b">
           <button
-            onClick={() => setActiveTab('add')}
+            onClick={() => handleTabChange('add')}
             className={`px-6 py-4 font-medium text-gray-700 transition-colors ${
               activeTab === 'add'
                 ? 'border-b-2 border-red-500 text-red-500'
@@ -47,7 +55,7 @@ export function AdminTabs({ userRole, attributes, creators, akyoData }: AdminTab
             新規登録
           </button>
           <button
-            onClick={() => setActiveTab('edit')}
+            onClick={() => handleTabChange('edit')}
             className={`px-6 py-4 font-medium text-gray-700 transition-colors ${
               activeTab === 'edit'
                 ? 'border-b-2 border-red-500 text-red-500'
@@ -58,7 +66,7 @@ export function AdminTabs({ userRole, attributes, creators, akyoData }: AdminTab
             編集・削除
           </button>
           <button
-            onClick={() => setActiveTab('tools')}
+            onClick={() => handleTabChange('tools')}
             className={`px-6 py-4 font-medium text-gray-700 transition-colors ${
               activeTab === 'tools'
                 ? 'border-b-2 border-red-500 text-red-500'

--- a/src/components/admin/attribute-modal.tsx
+++ b/src/components/admin/attribute-modal.tsx
@@ -9,6 +9,7 @@ interface AttributeModalProps {
   currentAttributes: string[];
   onApply: (attributes: string[]) => void;
   allAttributes: string[];
+  onCreateAttribute?: (attribute: string) => void;
 }
 
 /**
@@ -21,6 +22,7 @@ export function AttributeModal({
   currentAttributes,
   onApply,
   allAttributes,
+  onCreateAttribute,
 }: AttributeModalProps) {
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedAttributes, setSelectedAttributes] = useState<string[]>([]);
@@ -77,6 +79,7 @@ export function AttributeModal({
 
     setAvailableAttributes((prev) => [...prev, trimmed].sort());
     setSelectedAttributes((prev) => [...prev, trimmed]);
+    onCreateAttribute?.(trimmed);
     setNewAttributeName('');
     setShowCreateForm(false);
   };

--- a/src/components/admin/draft-keys.ts
+++ b/src/components/admin/draft-keys.ts
@@ -1,0 +1,1 @@
+export const ADD_TAB_DRAFT_KEY = 'akyodex:add-tab-draft-v1';


### PR DESCRIPTION
## Summary
- keep Add Tab draft inputs during transient submit failures (timeout/network/409 flow)
- persist draft in `sessionStorage` while staying in Add mode
- include newly created categories in draft restoration flow
- clear draft when leaving Add mode (switching to Edit/Tools), as requested

## Implementation
- add shared draft key constant: `src/components/admin/draft-keys.ts`
- `AddTab`
  - restore draft on mount
  - save draft on input/category changes
  - track user-created categories and feed them back into Attribute modal options
- `AdminTabs`
  - clear Add draft when active tab changes from `add` to another tab
- `AttributeModal`
  - expose `onCreateAttribute` callback so AddTab can retain custom categories

## Validation
- `npm run lint -- src/components/admin/admin-tabs.tsx src/components/admin/tabs/add-tab.tsx src/components/admin/attribute-modal.tsx src/components/admin/draft-keys.ts`
- `npx tsc --noEmit --incremental false`
