### PR TITLE
fix(zukan): switch to dynamic rendering to resolve CSP nonce mismatch

### DIFF
--- a/src/app/zukan/page.tsx
+++ b/src/app/zukan/page.tsx
@@ -1,13 +1,12 @@
 /**
- * Zukan Page - Server Component (Static Generation)
+ * Zukan Page - Server Component (Dynamic Rendering)
  * 
- * Performance optimizations:
- * - Static generation at build time
- * - ISR (Incremental Static Regeneration) every hour
- * - Parallel data fetching with React cache()
- * - Language detection moved to client-side for static caching
+ * Rendering strategy:
+ * - Dynamic rendering per request (force-dynamic) to ensure CSP nonce consistency
+ * - Parallel data fetching with React cache() + KV cache for performance
+ * - Language detection moved to client-side
  * 
- * Data is pre-rendered with Japanese (default language).
+ * Data is fetched with Japanese (default language).
  * Client component handles language detection and refetching if needed.
  */
 
@@ -38,15 +37,14 @@ export const metadata: Metadata = {
 /**
  * Server Component: Fetch data and render client component
  * 
- * Static Generation Optimization:
+ * Dynamic Rendering:
  * - Pre-renders with default language (Japanese)
  * - Parallel data fetching with Promise.all()
  * - React cache() prevents duplicate fetches
- * - ISR ensures CDN can cache this page for 1 hour
  * - Client handles language detection and refetching if needed
  */
 export default async function ZukanPage() {
-  // Use default language for static generation
+  // Use default language for initial render
   // Client component will detect user's language and refetch if needed
   const lang = DEFAULT_LANGUAGE;
 


### PR DESCRIPTION
## Summary

/zukan で「背景だけ表示されて UI が描画されない」問題を修正します。

## Root Cause

- middleware.ts はリクエストごとに新しい CSP nonce を生成
- /zukan は orce-static + ISR でキャッシュされていたため、HTML 内の nonce がビルド時の固定値
- ヘッダの nonce と HTML の nonce が不一致 → インラインスクリプトが CSP でブロック → UI が描画されない

## Fix

page.tsx の orce-static を orce-dynamic に変更し、毎リクエスト headers() から最新の nonce を取得するようにします。

## Changes

- src/app/zukan/page.tsx: orce-static + ISR → orce-dynamic

## Verification

- ✅ ビルド成功
- ✅ /zukan が Dynamic (ƒ) としてマーク

Closes #270

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * Zukanページを静的事前生成から動的レンダリングへ変更しました（表示がリクエスト単位で処理されます）。
* **Bug Fixes**
  * 固定されたHTML nonceのリスクを解消し、リクエストごとのCSP nonce生成に対応しました。
* **New Features**
  * 初回レンダリングは日本語を保持しつつ、クライアント側で言語検出と必要時の再取得を行うようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->