### PR TITLE
perf: Lighthouse スコア改善 (LCP/CLS Quick Wins)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -23,6 +23,9 @@ const nextConfig: NextConfig = {
     deviceSizes: [640, 750, 828, 1080, 1200, 1920],
     imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
 
+    // Cache optimized images for 30 days to improve repeat visit performance
+    minimumCacheTTL: 60 * 60 * 24 * 30,
+
     // Remote patterns for image sources
     remotePatterns: [
       {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,7 +11,8 @@ const mPlusRounded = M_PLUS_Rounded_1c({
   subsets: ['latin'],
   weight: ['400', '700'],
   display: 'swap',
-  preload: false,
+  preload: true,
+  adjustFontFallback: true,
 });
 
 export const viewport: Viewport = {
@@ -100,7 +101,11 @@ export default async function RootLayout({
 
   return (
     <html lang="ja" suppressHydrationWarning>
-      <head suppressHydrationWarning />
+      <head suppressHydrationWarning>
+        {/* Preconnect to image CDN to reduce LCP resource load delay */}
+        <link rel="preconnect" href="https://images.akyodex.com" />
+        <link rel="dns-prefetch" href="https://images.akyodex.com" />
+      </head>
       <body className={`${mPlusRounded.variable} antialiased`}>
         {children}
 
@@ -127,4 +132,3 @@ export default async function RootLayout({
     </html>
   );
 }
-


### PR DESCRIPTION
## 概要

PageSpeed Insights パフォーマンススコア **62点** を改善するための Quick Win 修正です。

## 変更内容

### 1. フォント読み込み最適化 (`src/app/layout.tsx`)

- `preload: false` → `preload: true` に変更
- `adjustFontFallback: true` を追加

**効果:** M PLUS Rounded 1c フォントが早期に読み込まれ、フォールバックフォントとのサイズ差が最小化されます。Lighthouse で検出された **CLS 0.313** のうち、ウェブフォント起因のシフトが大幅に改善される見込みです。

### 2. 画像 CDN への preconnect 追加 (`src/app/layout.tsx`)

```html
<link rel="preconnect" href="https://images.akyodex.com" />
<link rel="dns-prefetch" href="https://images.akyodex.com" />
```

**効果:** LCP 画像（R2 上の Akyo アバター画像）の DNS 解決・TLS ハンドシェイクを早期に開始。LCP 内訳の「リソース読み込みの遅延 1,070ms」を短縮します。

### 3. 画像キャッシュ TTL 設定 (`next.config.ts`)

```ts
minimumCacheTTL: 60 * 60 * 24 * 30, // 30日
```

**効果:** `_next/image` 経由の最適化画像がブラウザに 30 日間キャッシュされ、再訪問時の読み込み速度が向上します。Lighthouse で「効率的なキャッシュ保存期間を使用する（68 KiB）」と指摘されていた問題に対応。

## Lighthouse 指摘との対応

| Lighthouse 指摘 | 対応 | 期待効果 |
|---|---|---|
| CLS 0.313（ウェブフォント起因） | フォント preload + adjustFontFallback | CLS 大幅改善 |
| LCP 5.6秒（リソース読み込み遅延 1,070ms） | preconnect to images.akyodex.com | LCP 改善 |
| キャッシュ TTL なし（68 KiB） | minimumCacheTTL: 30日 | 再訪問改善 |

## 今後の改善候補（別 PR）

- [ ] レンダリングブロック CSS の分離（globals.css から モーダル/Dify スタイルを分離）
- [ ] ロゴ画像の `unoptimized` 削除 + リサイズ
- [ ] Sentry バンドルサイズ最適化
- [ ] 未使用 JS/CSS の削減

## テスト方法

1. `npm run dev` でローカル確認
2. デプロイ後に [PageSpeed Insights](https://pagespeed.web.dev/) で `/zukan` を再測定


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **パフォーマンス改善**
  * 画像キャッシュの最小有効期限を30日に設定
  * フォント事前ロード機能を有効化
  * CDNリソースヒントを追加してページ読み込み時間を短縮

<!-- end of auto-generated comment: release notes by coderabbit.ai -->