### PR TITLE
fix(build): restore IconDownload import in akyo-card

### DIFF
--- a/src/components/akyo-card.tsx
+++ b/src/components/akyo-card.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { IconImage, IconVRChat } from '@/components/icons';
+import { IconDownload, IconVRChat } from '@/components/icons';
 import { getCategoryColor, parseAndSortCategories } from '@/lib/akyo-data-helpers';
 import { generateBlurDataURL } from '@/lib/blur-data-url';
 import { t, type SupportedLanguage } from '@/lib/i18n';


### PR DESCRIPTION
## Cause
Cloudflare Pages build failed with TypeScript error in `src/components/akyo-card.tsx`:
`Cannot find name 'IconDownload'`.

`IconDownload` was used in JSX, but the import line had `IconImage` instead.

## Fix
- Updated import in `src/components/akyo-card.tsx`
  - from: `import { IconImage, IconVRChat } from '@/components/icons';`
  - to:   `import { IconDownload, IconVRChat } from '@/components/icons';`

## Validation
- Ran: `npm run next:build:opennext`
- Result: build passed locally.
