### PR TITLE
fix: avoid lost favorite toggles in use-akyo-data

### DIFF
--- a/src/hooks/use-akyo-data.ts
+++ b/src/hooks/use-akyo-data.ts
@@ -46,8 +46,8 @@ export function useAkyoData(initialData: AkyoData[] = []) {
   useEffect(() => {
     // 初期SSRデータ（isFavorite未同期）で localStorage を空上書きしない
     if (data.length === 0) return;
-    const hasSyncedFavoriteState = data.some((item) => typeof item.isFavorite === 'boolean');
-    if (!hasSyncedFavoriteState) return;
+    const hasFullySyncedFavoriteState = data.every((item) => typeof item.isFavorite === 'boolean');
+    if (!hasFullySyncedFavoriteState) return;
 
     const favorites = data.filter((item) => item.isFavorite).map((item) => item.id);
     saveFavorites(favorites);


### PR DESCRIPTION
## Summary
- switch `toggleFavorite` to functional `setData`/`setFilteredData` updates
- remove closure-based state derivation that could drop rapid consecutive toggles
- move favorites persistence out of toggle logic into a `useEffect` driven by `data`

## Verification
- npm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * お気に入りの永続化処理を一箇所に集約し、保存タイミングを安定化しました。
  * ハンドラ内の副作用（ストレージ書き込み）を削除して状態更新を簡素化しました。
  * 公開APIは変更せず、内部フローを改善して動作の信頼性を向上させました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->