### PR TITLE
fix: narrow favorites persistence triggers

### DIFF
--- a/src/hooks/use-akyo-data.ts
+++ b/src/hooks/use-akyo-data.ts
@@ -28,6 +28,8 @@ export function useAkyoData(initialData: AkyoData[] = []) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setData(dataWithFavorites);
       setFilteredData(dataWithFavorites);
+      // 初期復元時点の基準値を記録して、将来の差分判定を安定化させる
+      lastPersistedFavoritesRef.current = JSON.stringify(getFavorites());
     }
   }, [initialData]);
 


### PR DESCRIPTION
## Summary
- add a dirty ref so persistence runs only after favorite toggles
- skip save when the serialized favorites value did not change
- keep existing full-sync guard (`every(isFavorite === boolean)`) before persistence

## Verification
- npm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **改善**
  * お気に入りの保存処理を最適化し、ローカルストレージへの冗長な書き込みを削減しました。
  * 初回復元時の状態を保護し、不必要な上書きを避けるようになりました。
  * 他タブでの更新を検知して状態を正しく同期し、無駄な保存を回避します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->