### PR TITLE
fix(world): ワールドカードで最新のサムネイル画像を表示する

### DIFF
--- a/src/components/akyo-card.tsx
+++ b/src/components/akyo-card.tsx
@@ -132,16 +132,29 @@ export function AkyoCard({
           placeholder="blur"
           blurDataURL={generateBlurDataURL(akyo.id)}
           onError={() => {
-            // R2/Cloudflare失敗時はAPI経由にフォールバックし、それでも失敗したらプレースホルダー。
-            if (
-              imageSrc !== apiFallbackImageSrc &&
-              imageSrc !== placeholderImageSrc
-            ) {
-              setImageSrc(apiFallbackImageSrc);
-              return;
-            }
-            if (imageSrc !== placeholderImageSrc) {
-              setImageSrc(placeholderImageSrc);
+            if (isWorldEntry) {
+              // ワールド: VRChat API → R2画像 → placeholder
+              // bypassCloudflare パラメータは vrc-world-image では無視されるため、
+              // 冗長な再試行を避けてR2画像にフォールバックする
+              if (imageSrc === apiImageSrc) {
+                setImageSrc(primaryImageSrc);
+                return;
+              }
+              if (imageSrc !== placeholderImageSrc) {
+                setImageSrc(placeholderImageSrc);
+              }
+            } else {
+              // アバター: R2画像 → API(bypassCloudflare) → placeholder
+              if (
+                imageSrc !== apiFallbackImageSrc &&
+                imageSrc !== placeholderImageSrc
+              ) {
+                setImageSrc(apiFallbackImageSrc);
+                return;
+              }
+              if (imageSrc !== placeholderImageSrc) {
+                setImageSrc(placeholderImageSrc);
+              }
             }
           }}
         />


### PR DESCRIPTION
## 概要

ワールドのカード表示で、VRChatの最新サムネイル画像ではなく、R2に保存された古いサムネイル画像が表示されていた問題を修正しました。

## 問題

`akyo-card.tsx` では、ワールドもアバターも区別なく R2 ストレージ (`images.akyodex.com/{id}.webp`) の画像を初期表示していました。R2 には登録時にアップロードされた画像が保存されているため、ワールドのサムネイルが後から更新されても **R2上の古い画像がそのまま表示され続けていました**。

一方で `akyo-list.tsx`（リスト表示）や `akyo-detail-modal.tsx`（詳細モーダル）ではワールドの場合に `buildAvatarImageUrl` → `/api/vrc-world-image?wrld=xxx` を直接使っていたため、常に VRChat から最新の OGP 画像を取得できていました。

## 修正内容

- **ワールドの場合**: 初期画像を `apiImageSrc`（= `/api/vrc-world-image?wrld=xxx&w=512`）に変更 → VRChat から最新のサムネイルを常にフェッチ
- **アバターの場合**: 従来通り R2 画像を初期表示（管理画面で手動アップロードされた画像を優先）
- `entryType` / `isWorldEntry` の算出を `useState` の前に移動し、初期レンダリングの時点で正しいソースを選択

## 変更ファイル

- `src/components/akyo-card.tsx`

## テスト

- `npm run build` ✅
- `npm run lint` ✅
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rad-vrc/akyodex/pull/325" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
