### PR TITLE
fix: X(Twitter)カードの画像をlogo-200.pngに変更

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -47,10 +47,10 @@ export const metadata: Metadata = {
     images: [{ url: '/opengraph-image', width: 1200, height: 630, alt: 'Akyoずかん ロゴ' }],
   },
   twitter: {
-    card: 'summary_large_image',
+    card: 'summary',
     title: 'Akyoずかん-VRChatアバター Akyo図鑑-',
     description: 'VRChatに潜むなぞ生物アバター「Akyo」を500体以上収録した図鑑サイト。名前・作者・属性で探せる日本語対応の共有データベースで、今日からキミもAkyoファインダーの仲間入り!',
-    images: ['/opengraph-image'],
+    images: ['https://akyodex.com/images/logo-200.png'],
     creator: '@akyodex',
   },
   icons: {


### PR DESCRIPTION
## 変更内容

- \	witter.images\ を動的OG画像（\/opengraph-image\）から \logo-200.png\ に変更
- \	witter.card\ を \summary_large_image\ から \summary\ に変更（200px画像に適したカードタイプ）

## 変更ファイル

- \src/app/layout.tsx\ — twitter メタデータ修正
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rad-vrc/akyodex/pull/332" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * ソーシャルメディア共有時のメタデータ設定を改善しました。Twitter共有時のカード形式を更新し、画像URLを絶対URLに変更して、プラットフォーム上での表示の一貫性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->