### PR TITLE
docs: refresh Cloudflare Pages runbooks

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,724 +1,299 @@
 # CI/CD Workflows Documentation
 
-このドキュメントでは、Akyodex Next.js プロジェクトの GitHub Actions CI/CD ワークフローについて説明します。
-
-## 📋 目次
-
-1. [ワークフロー概要](#ワークフロー概要)
-2. [CI - Continuous Integration](#ci---continuous-integration)
-3. [Cloudflare Pages デプロイメント](#cloudflare-pages-デプロイメント)
-4. [セキュリティ監査](#セキュリティ監査)
-5. [Cloudflare リソース検証](#cloudflare-リソース検証)
-6. [Next.js Health Check](#nextjs-health-check)
-7. [再利用可能なビルドワークフロー](#再利用可能なビルドワークフロー)
-8. [必要なシークレットと変数](#必要なシークレットと変数)
-9. [ベストプラクティス](#ベストプラクティス)
-10. [トラブルシューティング](#トラブルシューティング)
-11. [関連ドキュメント](#関連ドキュメント)
-
----
+このドキュメントは `.github/workflows/*.yml` の現行実装を起点にした運用メモです。README と YAML が食い違う場合は、YAML を正として扱ってください。
 
 ## 📚 関連ドキュメント
 
-このディレクトリには、以下の追加ドキュメントが含まれています:
+このディレクトリには、以下の補助ドキュメントがあります。
 
 | ドキュメント | 内容 |
-|------------|------|
-| **ARCHITECTURE.md** | ワークフローのアーキテクチャ図、フロー、セキュリティレイヤー |
-| **QUICKSTART.md** | 5分セットアップガイド（日本語） |
-| **SUMMARY.md** | 実装サマリーと完了チェックリスト |
-| **NEXTDEVTOOLS-IMPROVEMENTS.md** | Next.js DevTools を活用した改善内容と Next.js 16 移行パス |
-| **WORKERS-VS-PAGES-ANALYSIS.md** | ⭐ Cloudflare Workers vs Pages 詳細比較分析 |
-
-### 🔍 Cloudflare Workers vs Pages について
-
-**重要**: このプロジェクトは Cloudflare Pages を使用していますが、Cloudflare Workers への移行を検討する際は `WORKERS-VS-PAGES-ANALYSIS.md` を参照してください。
-
-**調査結果サマリー**:
-- ✅ **推奨**: Cloudflare Pages での継続使用
-- ❌ **非推奨**: Cloudflare Workers への移行（現時点では不要）
-- 📝 **理由**: Pages は Next.js 15 + App Router に最適化されており、Git 統合とプレビューデプロイが有用
-- 🔄 **Next.js 16 移行**: Pages のまま移行可能（Workers への移行は不要）
-
-詳細な技術比較、移行手順、リスク分析は `WORKERS-VS-PAGES-ANALYSIS.md` を参照。
-
----
+| ------------ | ---- |
+| `ARCHITECTURE.md` | ワークフロー全体の設計背景 |
+| `QUICKSTART.md` | GitHub Actions / Cloudflare の初期セットアップ |
+| `SUMMARY.md` | 導入時のサマリー |
+| `NEXTDEVTOOLS-IMPROVEMENTS.md` | Next.js / CI 改善メモ |
+| `WORKERS-VS-PAGES-ANALYSIS.md` | Workers と Pages の比較検討 |
 
 ## ワークフロー概要
 
-このプロジェクトには、以下の GitHub Actions ワークフローが実装されています：
+| ワークフロー | ファイル | トリガー | 主な役割 | 補足 |
+| ------------- | --------- | --------- | --------- | ---- |
+| CI | `ci.yml` | PR / push (`main`, `develop`) | 型チェック、Cloudflare Pages ビルド検証、Security Scan | ESLint と Dify CSP hash は advisory |
+| Deploy to Cloudflare Pages | `deploy-cloudflare-pages.yml` | `main` push / manual | 本番または手動環境への Pages デプロイ | URL ヘルスチェック付き |
+| Cloudflare Pages Preview Gate | `cloudflare-pages-preview-gate.yml` | non-draft PR (`main`, `develop`) | PR の preview 成否をゲート | Cloudflare API + GitHub check-run fallback |
+| Conflict Check | `conflict-check.yml` | PR to `main`, push to `main` | `main` との競合をコメントで通知 | 競合解消時は古いコメントを削除 |
+| Sync JSON Data from CSV | `sync-json-data.yml` | `main` push (CSV変更時) / manual | CSV→JSON 変換、R2 アップロード、ISR 再検証 | GitHub へ自動コミットも行う |
+| Weekly Security Audit | `security-audit.yml` | weekly / manual | `npm audit`、Snyk、CodeQL、Issue 作成 | Snyk は token がある場合のみ有効 |
+| Validate Cloudflare Resources | `validate-cloudflare-resources.yml` | daily / manual | R2/KV/CSV の健全性確認 | CSV チェックは legacy path 前提 |
+| Next.js Health Check | `nextjs-health-check.yml` | PR (Next.js関連パス変更時) / manual | Next.js / Pages 互換性の advisory チェック | 警告中心で deploy の本線ではない |
+| Lint project | `knip.yml` | PR / push (`main`, `cloudflare-opennext-test`) | `npm run knip` 実行 | dead-code / unused export 検知 |
+| Claude Code Review | `claude-code-review.yml` | `@claude` メンション | Claude による issue / PR 補助 | 人手レビューの代替ではない |
+| Reusable Build | `reusable-build.yml` | `workflow_call` | 再利用可能なビルド共通化 | 現在の本線 deploy/CI からは直接参照されていない |
 
-| ワークフロー | ファイル | トリガー | 目的 |
-|------------|---------|---------|------|
-| **CI** | `ci.yml` | PR, Push | Lint、型チェック、ビルド検証、セキュリティスキャン |
-| **Deploy** | `deploy-cloudflare-pages.yml` | Push to main, Manual | Cloudflare Pages へのデプロイ |
-| **Pages Preview Gate** | `cloudflare-pages-preview-gate.yml` | PR | Cloudflare Pages プレビュー成否をPR上で自動ゲート |
-| **Security Audit** | `security-audit.yml` | 毎週月曜日, Manual | 依存関係の脆弱性スキャン |
-| **Validate Resources** | `validate-cloudflare-resources.yml` | 毎日, Manual | R2/KV/CSV データの整合性チェック |
-| **Reusable Build** | `reusable-build.yml` | Workflow call | 共通ビルドロジック（DRY原則） |
-| **Next.js Health Check** | `nextjs-health-check.yml` | PR (コード変更時) | Next.js設定とベストプラクティス検証 |
+### 推奨 Required Checks
 
-### PRマージ前の必須チェック推奨
-
-Cloudflare Pages のデプロイ失敗を見逃さないため、GitHub の Branch protection で以下チェックを **Required** に設定してください。
+Branch protection で最低限 Required にしたいのは次の 2 つです。
 
 - `CI - Continuous Integration / Build Validation`
 - `Cloudflare Pages Preview Gate / Verify Cloudflare Pages Preview`
 
----
-
-## CI - Continuous Integration
-
-**ファイル**: `.github/workflows/ci.yml`
-
-### トリガー条件
-
-```yaml
-on:
-  pull_request:
-    branches: [main, develop]
-  push:
-    branches: [main, develop]
-```
-
-### ジョブ構成
-
-#### 1. Lint & Type Check
-- ESLint による静的解析
-- TypeScript の型チェック
-- 依存関係: なし
-
-#### 2. Build Validation
-- Cloudflare Pages 用のビルド実行
-- ビルド成果物の検証
-- アーティファクトのアップロード (7日間保持)
-- 依存関係: lint-and-typecheck
-
-#### 3. Security Scan
-- npm audit 実行
-- CodeQL による静的セキュリティ分析
-- 依存関係: lint-and-typecheck
-
-#### 4. Dependency Review (PR のみ)
-- 依存関係の変更レビュー
-- 中程度以上の脆弱性でフェイル
-- 依存関係: なし
-
-#### 5. Build Performance Report (PR のみ)
-- ビルド時間の測定
-- ビルドサイズの分析
-- 依存関係: build-validation
-
-### 最適化機能
-
-- **並行実行制御**: 同一コミットに対する重複実行を防止
-  ```yaml
-  concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
-  ```
-
-- **npm キャッシュ**: 依存関係のインストール時間を短縮
-  ```yaml
-  cache: 'npm'
-  ```
-
-- **Next.js ビルドキャッシュ**: `.next/cache` と `.open-next` をキャッシュ
-  ```yaml
-  - uses: actions/cache@v4
-    with:
-      path: |
-        .next/cache
-        .open-next
-      key: ${{ runner.os }}-nextjs-${{ hashFiles('package-lock.json') }}-${{ hashFiles('**/*.ts', '**/*.tsx') }}
-  ```
-  
-  **効果**: 
-  - 初回ビルド: ~2-3分
-  - キャッシュヒット時: ~1-2分（30-50% 高速化）
-  - Next.js の増分ビルド機能を活用
-
-- **ビルド検証**: 重要なファイルの存在を確認
-  ```bash
-  test -f .open-next/_worker.js  # Worker スクリプト
-  test -f .open-next/_routes.json  # ルート設定
-  test -d .open-next/_next  # Next.js アセット
-  ```
-
-### 実行例
-
-```bash
-# PR を作成時に自動実行
-git checkout -b feature/my-feature
-git commit -m "feat: add new feature"
-git push origin feature/my-feature
-# → GitHub で PR 作成 → CI 自動実行
-```
-
----
-
-## Cloudflare Pages デプロイメント
-
-**ファイル**: `.github/workflows/deploy-cloudflare-pages.yml`
-
-### トリガー条件
-
-```yaml
-on:
-  push:
-    branches: [main]
-  workflow_dispatch:  # 手動実行可能
-    inputs:
-      environment:
-        type: choice
-        options: [production, staging]
-```
+`Conflict Check` は有用ですが、補助的なコメント通知として扱うのが実運用に合っています。
 
-### デプロイフロー
+## 通常の開発フロー
 
-1. **ビルド準備**
-   - Node.js 20 セットアップ
-   - 依存関係インストール (npm ci)
+1. ローカルで作業し、コミットする。
+2. `git push` する。
+3. PowerShell では repo 既定の wrapper が push 後に PR 状態を確認する。
+4. それ以外の shell では `npm run push:check-pr -- -u origin HEAD` を使うと push と PR 状態確認をまとめて実行できる。
+5. PR を開くと `CI` と `Cloudflare Pages Preview Gate` が走る。
+6. `main` にマージされると `Deploy to Cloudflare Pages` が走る。
+7. CSV を更新した commit が `main` に入ると `Sync JSON Data from CSV` が追加で走る。
 
-2. **ビルド実行**
-   - `npm run build` で OpenNext Cloudflare ビルド
-   - 環境変数は Cloudflare Pages ダッシュボードで設定済みのものを使用
+## Cloudflare Pages Preview Gate
 
-3. **ビルド検証**
-   - `.open-next` ディレクトリの存在確認
-   - ビルド成果物のサイズ確認
+**ファイル**: `cloudflare-pages-preview-gate.yml`
 
-4. **Cloudflare Pages デプロイ**
-   - `wrangler-action@v3` を使用
-   - プロジェクト名: `akyodex`
+### 何をしているか
 
-5. **デプロイサマリー作成**
-   - GitHub Step Summary に結果表示
-   - PR の場合はコメント投稿
+- non-draft PR が `main` または `develop` を向いているときだけ実行します。
+- fork PR では Cloudflare secrets にアクセスできないため、明示的に skip します。
+- `vars.CLOUDFLARE_PAGES_PROJECT` を第 1 候補、`akyodex` を fallback 候補として preview deployment を探します。
+- Cloudflare API の deployment metadata から `PR_HEAD_SHA` と branch を一致させて preview を特定します。
+- Cloudflare 側 metadata に commit 情報が載らない場合は、GitHub の check run `Cloudflare Pages` を fallback として参照します。
 
-### 環境変数
+### 責務分担
 
-デプロイ時は Cloudflare Pages ダッシュボードで設定した環境変数が優先されます。
-GitHub Secrets はビルドプロセスのフォールバック用です。
+- PR preview の source of truth は Cloudflare Pages の Git-connected preview deployment です。
+- この workflow 自体は preview を作らず、出来上がった preview の成否を待って判定します。
+- production/manual deploy の source of truth は `deploy-cloudflare-pages.yml` の `wrangler pages deploy` です。
 
-```yaml
-env:
-  ADMIN_PASSWORD_HASH: ${{ secrets.ADMIN_PASSWORD_HASH }}
-  OWNER_PASSWORD_HASH: ${{ secrets.OWNER_PASSWORD_HASH }}
-  JWT_SECRET: ${{ secrets.JWT_SECRET }}
-  NEXT_PUBLIC_SITE_URL: ${{ vars.NEXT_PUBLIC_SITE_URL }}
-  NEXT_PUBLIC_R2_BASE: ${{ vars.NEXT_PUBLIC_R2_BASE }}
-```
+### 待機ポリシー
 
-### 手動デプロイ
+- 最大 36 回ポーリング
+- 前半は 5 秒間隔、中盤は 10 秒間隔、後半は 20 秒間隔
+- job 自体の timeout は 15 分
 
-GitHub UI から手動実行可能：
+### 成功時の見え方
 
-1. Actions タブ → "Deploy to Cloudflare Pages" を選択
-2. "Run workflow" をクリック
-3. 環境 (production/staging) を選択
-4. "Run workflow" を実行
+- Step Summary に deployment ID と preview URL を出力します。
+- Cloudflare API で preview が見つかった場合も、GitHub check-run fallback で成功した場合も success 扱いです。
 
----
+### 失敗時の見え方
 
-## セキュリティ監査
+- PR に失敗コメントを自動投稿または更新します。
+- コメントには Actions run URL が含まれます。
 
-**ファイル**: `.github/workflows/security-audit.yml`
+### Runbook
 
-### トリガー条件
+Preview Gate が失敗または timeout したら、次を上から順に確認してください。
 
-```yaml
-on:
-  schedule:
-    - cron: '0 9 * * 1'  # 毎週月曜日 9:00 UTC
-  workflow_dispatch:     # 手動実行可能
-```
+1. `CLOUDFLARE_PAGES_PROJECT` が実際の Pages project 名と一致しているか。
+2. Cloudflare Pages 側で対象 commit の preview deployment が作成されているか。
+3. GitHub checks に `Cloudflare Pages` という check run が出ているか。
+4. fork PR ではないか。fork PR なら secrets 非公開のため gate は skip が正常です。
 
-### 監査内容
+## Deploy to Cloudflare Pages
 
-#### 1. npm audit
-- npm の脆弱性データベースをスキャン
-- 中程度以上の脆弱性を検出
-- 結果を JSON で保存 (30日間保持)
+**ファイル**: `deploy-cloudflare-pages.yml`
 
-#### 2. Snyk Security Scan (オプション)
-- Snyk トークンが設定されている場合に実行
-- より詳細な脆弱性分析
+### トリガー
 
-#### 3. CodeQL 分析
-- `security-extended` クエリセットを使用
-- JavaScript/TypeScript の静的分析
+- `push` to `main`
+- `workflow_dispatch` with `environment=production|staging`
 
-#### 4. 古い依存関係チェック
-- `npm outdated` を実行
-- アップデート可能なパッケージをレポート
+`environment=staging` は GitHub Actions の environment label を切り替えるだけです。Pages project、R2、KV、runtime secrets を分離したい場合は、workflow input とは別に Cloudflare 側の project / binding / secret 設計を分けてください。
 
-#### 5. Issue 自動作成
-- 脆弱性が見つかった場合、GitHub Issue を自動作成
-- ラベル: `security`, `automated`
+### 実行フロー
 
-### Snyk 統合 (オプション)
+1. Node.js 20 をセットアップし、npm cache と `.next/cache` を復元
+2. `npm ci`
+3. `npm run build`
+4. `.open-next`、`_worker.js`、`_routes.json`、`_next/` の存在を検証
+5. `cloudflare/wrangler-action@v3` で `pages deploy .open-next --project-name=${CF_PAGES_PROJECT}`
+6. deployment URL に対して HTTP ヘルスチェック
+7. Step Summary に deploy 結果を記録
 
-Snyk を使用する場合は、以下のシークレットを設定：
+### ヘルスチェック仕様
 
-```bash
-# GitHub Settings → Secrets → Actions
-SNYK_TOKEN=your_snyk_api_token
-```
+- 対象: `steps.deployment.outputs.url`
+- 成功条件: HTTP `200` / `301` / `302`
+- リトライ: 10 回
+- 間隔: 3 秒
 
----
+### Step Summary の読み方
 
-## Cloudflare リソース検証
+| 状態 | 意味 |
+| ---- | ---- |
+| `Deploy Step=success`, `Health Check=healthy` | deploy と URL 応答が両方成功 |
+| `Deploy Step=success`, `Health Check=missing_url` | deploy 自体は成功したが action が URL を返さなかった |
+| `Deploy Step=success`, `Health Check=unhealthy` | deploy 後の URL が想定 HTTP を返さなかった |
+| `Deploy Step!=success` | Wrangler deploy そのものが失敗 |
 
-**ファイル**: `.github/workflows/validate-cloudflare-resources.yml`
+### 実装上の注意点
 
-### トリガー条件
+- workflow は `CF_PAGES_PROJECT=${{ vars.CLOUDFLARE_PAGES_PROJECT || 'akyodex' }}` を使います。
+- build step では `DEFAULT_ADMIN_PASSWORD_HASH` / `DEFAULT_OWNER_PASSWORD_HASH` / `DEFAULT_JWT_SECRET` 由来の legacy fallback をまだ export しています。
+- ただし runtime code が読むのは `ADMIN_PASSWORD_OWNER`, `ADMIN_PASSWORD_ADMIN`, `SESSION_SECRET` です。workflow 側の legacy defaults は runtime source of truth ではありません。
+- workflow ファイルには PR コメント step がありますが、現在の trigger は `push` と `workflow_dispatch` のみなので、その step は通常到達しません。
 
-```yaml
-on:
-  schedule:
-    - cron: '0 6 * * *'  # 毎日 6:00 UTC
-  workflow_dispatch:     # 手動実行可能
-```
+## CI とマージ安全性
 
-### 検証内容
+### CI (`ci.yml`)
 
-#### 1. R2 Storage 検証
-- wrangler.toml の確認
-- R2 バケットへのアクセス確認
-- バケットリストの取得
+`ci.yml` は 5 つの job で構成されています。
 
-#### 2. KV Namespace 検証
-- KV Namespace へのアクセス確認
-- Namespace リストの取得
+| Job | 役割 | Gating |
+| --- | ---- | ------ |
+| `lint-and-typecheck` | Dify CSP hash 検証、ESLint、TypeScript | TypeScript は hard fail、Dify hash と ESLint は `continue-on-error` |
+| `build-validation` | Cloudflare Pages build と成果物検証 | Required check 候補 |
+| `security-scan` | `npm audit` と CodeQL | `npm audit` は advisory |
+| `dependency-review` | 依存関係レビュー (PR only) | 中程度以上で fail |
+| `build-performance` | build 時間とサイズの計測 (PR only) | レポート用途 |
 
-#### 3. CSV データ検証
-- CSV ファイルの存在確認
-  - `data/akyo-data.csv` (日本語)
-  - `data/akyo-data-US.csv` (英語)
-- レコード数のカウント
-- 空ファイルチェック
+### Conflict Check (`conflict-check.yml`)
 
-#### 4. ヘルスチェックレポート
-- 各検証の結果を集計
-- ステータスサマリーを作成
-- 失敗時は次のステップを提示
+- PR to `main`: PR head に `origin/main` を merge して競合有無を確認
+- `main` push: open PR 一覧をなめて mergeable 状態を再チェック
+- 競合がある場合は PR コメントを作成/更新
+- 競合が解消された場合は過去コメントを削除
 
-### 実行例
+### ローカル push helper
 
-```bash
-# 手動実行
-GitHub Actions タブ → "Validate Cloudflare Resources" → "Run workflow"
-```
+repo ルートの `npm run push:check-pr` は次をまとめて行います。
 
----
+- 既に merged 済み PR に紐づく branch かどうかのガード
+- 必要なら `git push`
+- 対象 branch の open PR を `gh pr list` で確認
+- mergeability pending の場合は retry 後に exit code `4`
 
-## Next.js Health Check
+主な exit code:
 
-**ファイル**: `.github/workflows/nextjs-health-check.yml`
+- `2`: open PR が conflicted (`mergeable=CONFLICTING` or `mergeStateStatus=DIRTY`)
+- `4`: GitHub が mergeability をまだ計算中
+- `5`: 現在の branch は既に merged PR に紐づいているので、新しい branch / PR を使うべき
 
-### トリガー条件
+## データ同期と補助ワークフロー
 
-```yaml
-on:
-  pull_request:
-    paths:
-      - 'src/**'
-      - 'app/**'
-      - 'pages/**'
-      - 'next.config.*'
-      - 'package.json'
-  workflow_dispatch:
-```
+### Sync JSON Data from CSV (`sync-json-data.yml`)
 
-### 検証内容
+- `data/akyo-data-ja.csv`, `data/akyo-data-en.csv`, `data/akyo-data-ko.csv` の変更で起動
+- `npm run data:convert` で JSON を再生成
+- 差分があれば JSON をコミットして push
+- R2 へ `data/akyo-data-*.json` をアップロード
+- `REVALIDATE_SECRET` があれば `/api/revalidate` を叩いて ISR と KV cache 更新を促す
 
-#### 1. Next.js バージョンチェック
-- Next.js のバージョンを確認
-- Next.js 15.5+ の使用を推奨
+### Validate Cloudflare Resources (`validate-cloudflare-resources.yml`)
 
-#### 2. App Router 構造検証
-- App Router の使用確認
-- params/searchParams の適切な await 処理確認
-- Next.js 15 の非同期 API 対応
+この workflow は次を確認します。
 
-#### 3. 非推奨パターンチェック
-- getServerSideProps/getStaticProps の誤用検出
-- レガシー Image コンポーネントの使用検出
-- Pages Router メソッドの App Router での使用検出
+- Wrangler 経由での R2 bucket access
+- Wrangler 経由での KV namespace access
+- CSV ファイル存在確認
 
-#### 4. Cloudflare Pages 互換性
-- Edge Runtime 互換性チェック
-- Node.js API の誤用検出（fs, child_process など）
-- runtime export の検証
+ただし現行 YAML では CSV チェックが legacy path のままです。
 
-#### 5. ビルド設定検証
-- next.config の存在確認
-- Turbopack の使用確認
-- 画像最適化設定の確認
+- `data/akyo-data.csv`
+- `data/akyo-data-US.csv`
 
-#### 6. バンドル最適化分析
-- 大きな依存関係の検出
-- Dynamic imports の使用確認
-- コード分割の推奨
+現在の repo で使っている実ファイルは `data/akyo-data-ja.csv` と `data/akyo-data-en.csv` なので、CSV step の失敗は workflow drift である可能性を先に疑ってください。
 
-### 実行例
+### Weekly Security Audit (`security-audit.yml`)
 
-```bash
-# PR を作成すると自動実行（コード変更時）
-git checkout -b feature/my-feature
-# src/ 配下を変更
-git push origin feature/my-feature
-# → GitHub で PR 作成 → Health Check 自動実行
-```
+- weekly/manual で実行
+- `npm audit --json`
+- Snyk scan (`SNYK_TOKEN` がある場合)
+- CodeQL analyze
+- outdated dependencies report
+- 脆弱性が見つかった場合は GitHub Issue を自動作成
 
----
+### Next.js Health Check (`nextjs-health-check.yml`)
 
-## 再利用可能なビルドワークフロー
+- Next.js 関連ファイル変更時に実行
+- App Router、deprecated pattern、Pages 互換性、画像設定などを grep ベースで確認
+- 警告中心の advisory workflow であり、Cloudflare deploy の source of truth ではありません
 
-**ファイル**: `.github/workflows/reusable-build.yml`
+注意:
 
-### 概要
+- この workflow は `export const runtime = 'nodejs'` を warning することがあります。
+- 本 repo には意図的に Node.js runtime を使う API route もあるため、警告はコード文脈と合わせて判断してください。
 
-DRY (Don't Repeat Yourself) 原則に従い、共通ビルドロジックを再利用可能なワークフローとして定義。
+### Lint / Claude / Reusable Build
 
-### 入力パラメータ
-
-```yaml
-inputs:
-  node-version: '20'           # Node.js バージョン
-  upload-artifacts: false      # アーティファクトをアップロードするか
-  artifact-name: 'build-output' # アーティファクト名
-```
-
-### 出力
-
-```yaml
-outputs:
-  build-time: ビルド時間 (秒)
-  build-size: ビルドサイズ (バイト)
-```
-
-### 使用例
-
-他のワークフローから呼び出す：
-
-```yaml
-jobs:
-  build:
-    uses: ./.github/workflows/reusable-build.yml
-    with:
-      node-version: '20'
-      upload-artifacts: true
-      artifact-name: 'my-build'
-    secrets: inherit
-```
-
-### 最適化機能
-
-- **node_modules キャッシュ**: インストール時間を短縮
-- **ビルドメトリクス**: 時間とサイズを出力
-- **柔軟な設定**: プロジェクトに応じてカスタマイズ可能
-
----
+- `knip.yml`: `npm run knip` による dead-code 検査
+- `claude-code-review.yml`: `@claude` メンション時のみ起動する補助 workflow
+- `reusable-build.yml`: 将来の caller 向け build helper。現時点では本線 CI/deploy からは直接呼ばれていません
 
 ## 必要なシークレットと変数
 
-### GitHub Secrets
+### GitHub Actions 側
 
-以下のシークレットを GitHub リポジトリ設定で追加してください：
+| 名前 | 主な用途 | 必須 |
+| ---- | -------- | ---- |
+| `CLOUDFLARE_API_TOKEN` | Deploy / Preview Gate | Yes |
+| `CLOUDFLARE_ACCOUNT_ID` | Deploy / Preview Gate | Yes |
+| `CLOUDFLARE_PAGES_PROJECT` | Deploy / Preview Gate の project 解決 | Recommended |
+| `NEXT_PUBLIC_SITE_URL` | build-time fallback | Optional |
+| `NEXT_PUBLIC_R2_BASE` | build-time fallback | Optional |
+| `DEFAULT_ADMIN_PASSWORD_HASH` | legacy build fallback | Optional |
+| `DEFAULT_OWNER_PASSWORD_HASH` | legacy build fallback | Optional |
+| `DEFAULT_JWT_SECRET` | legacy build fallback | Optional |
+| `R2_ACCESS_KEY_ID` | JSON sync の R2 upload | `sync-json-data.yml` で必須 |
+| `R2_SECRET_ACCESS_KEY` | JSON sync の R2 upload | `sync-json-data.yml` で必須 |
+| `REVALIDATE_SECRET` | JSON sync 後の ISR 再検証 | Recommended |
+| `SNYK_TOKEN` | Weekly Security Audit | Optional |
+| `ANTHROPIC_API_KEY` | Claude Code Review | `@claude` workflow で必須 |
 
-| シークレット名 | 必須 | 説明 |
-|--------------|------|------|
-| `CLOUDFLARE_API_TOKEN` | ✅ Yes | Cloudflare API トークン (デプロイ用) |
-| `CLOUDFLARE_ACCOUNT_ID` | ✅ Yes | Cloudflare アカウント ID |
-| `SNYK_TOKEN` | 🔵 Optional | Snyk API トークン (セキュリティ監査用) |
+### Cloudflare runtime 側
 
-**注意**: パスワードハッシュと JWT シークレットは、セキュリティのため GitHub Variables に設定します。
-
-### GitHub Variables
-
-| 変数名 | 必須 | 説明 | デフォルト値 |
-|-------|------|------|------------|
-| `DEFAULT_ADMIN_PASSWORD_HASH` | ✅ Yes | ビルド用管理者パスワードハッシュ | - |
-| `DEFAULT_OWNER_PASSWORD_HASH` | ✅ Yes | ビルド用オーナーパスワードハッシュ | - |
-| `DEFAULT_JWT_SECRET` | ✅ Yes | ビルド用 JWT シークレット | - |
-| `CLOUDFLARE_PAGES_PROJECT` | 🔵 Optional | Cloudflare Pages プロジェクト名（Preview Gate用） | `akyodex` |
-| `NEXT_PUBLIC_SITE_URL` | 🔵 Optional | サイト URL | - |
-| `NEXT_PUBLIC_R2_BASE` | 🔵 Optional | R2 ベース URL | - |
-
-**重要**: 本番用の環境変数は、必ず Cloudflare Pages ダッシュボードで設定してください。
-GitHub Variables はビルドプロセス用の値です。
-
-### Cloudflare API トークンの作成
-
-1. Cloudflare ダッシュボード → My Profile → API Tokens
-2. "Create Token" をクリック
-3. "Edit Cloudflare Workers" テンプレートを選択
-4. 以下の権限を付与：
-   - Account → Cloudflare Pages → Edit
-   - Account → Account Settings → Read
-5. トークンをコピーして GitHub Secrets に追加
-
-### 環境変数の設定方法
-
-```bash
-# GitHub リポジトリで設定
-# Secrets (Settings → Secrets and variables → Actions → New repository secret)
-CLOUDFLARE_API_TOKEN
-CLOUDFLARE_ACCOUNT_ID
-SNYK_TOKEN (optional)
-
-# Variables (Settings → Secrets and variables → Actions → Variables → New repository variable)
-DEFAULT_ADMIN_PASSWORD_HASH
-DEFAULT_OWNER_PASSWORD_HASH
-DEFAULT_JWT_SECRET
-NEXT_PUBLIC_SITE_URL
-NEXT_PUBLIC_R2_BASE
-
-# Cloudflare Pages で設定 (本番用)
-Cloudflare Pages ダッシュボード
-→ プロジェクト選択 → Settings → Environment variables
-ADMIN_PASSWORD_HASH (本番用の値)
-OWNER_PASSWORD_HASH (本番用の値)
-JWT_SECRET (本番用の値)
-```
-
-**重要**: 
-- GitHub Variables は CI/CD ビルドプロセス用です
-- 本番環境の実際の値は Cloudflare Pages ダッシュボードで設定してください
-- Secrets と Variables を混同しないでください（Secrets は暗号化、Variables は平文）
-
----
-
-## ベストプラクティス
-
-### 1. ブランチ戦略
-
-```
-main (本番)
-  ← develop (開発)
-    ← feature/* (機能開発)
-    ← bugfix/* (バグ修正)
-    ← hotfix/* (緊急修正)
-```
-
-### 2. PR ワークフロー
-
-```bash
-# 1. 機能ブランチを作成
-git checkout -b feature/my-feature
-
-# 2. 変更をコミット
-git add .
-git commit -m "feat: add new feature"
-
-# 3. PR を作成
-git push origin feature/my-feature
-# → GitHub で PR 作成
-
-# 4. CI が自動実行
-# - Lint & Type Check
-# - Build Validation
-# - Security Scan
-# - Dependency Review
-
-# 5. レビュー後、main にマージ
-# → 自動デプロイ実行
-```
-
-### 3. コミットメッセージ規約
-
-```bash
-feat: 新機能追加
-fix: バグ修正
-docs: ドキュメント更新
-style: コードフォーマット
-refactor: リファクタリング
-test: テスト追加
-chore: ビルド設定など
-```
-
-### 4. セキュリティ
-
-- **シークレットは絶対にコミットしない**
-- **定期的なセキュリティ監査を実施**
-- **依存関係を最新に保つ**
-- **CodeQL 警告は速やかに対応**
-
-### 5. パフォーマンス
-
-- **npm キャッシュを活用**
-- **並行実行制御で重複ビルドを防止**
-- **必要なジョブのみ実行**
-
----
+| 名前 | 用途 |
+| ---- | ---- |
+| `ADMIN_PASSWORD_OWNER` | owner login |
+| `ADMIN_PASSWORD_ADMIN` | admin login |
+| `SESSION_SECRET` | session HMAC signing |
+| `NEXT_PUBLIC_APP_URL` | CSRF origin 判定 |
+| `NEXT_PUBLIC_R2_BASE` | public image/data base URL |
+| `GITHUB_TOKEN` / `GITHUB_*` | admin-side CSV sync |
+| `REVALIDATE_SECRET` | `/api/revalidate` |
 
 ## トラブルシューティング
 
-### ビルドが失敗する
+### Preview Gate が skip された
 
-#### 症状
-```
-Error: Cannot find module '@opennextjs/cloudflare'
-```
+- fork PR か確認してください。
+- fork PR なら `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` が読めないため skip が正常です。
+- fork PR の author が自力で確認できるのは GitHub 上の CI と一般的なアプリ動作までです。Cloudflare preview / secrets 依存の確認は maintainer 側で行う必要があります。
 
-#### 解決策
-```bash
-# 依存関係を再インストール
-rm -rf node_modules package-lock.json
-npm install
-```
+### Preview Gate が timeout / failed した
 
----
+1. `CLOUDFLARE_PAGES_PROJECT` の値を確認する
+2. Cloudflare Pages の preview deployment 一覧で対象 commit を探す
+3. GitHub checks の `Cloudflare Pages` を確認する
+4. 必要なら rerun する
 
-### デプロイが失敗する
+### Deploy workflow が `missing_url` になった
 
-#### 症状
-```
-Error: Invalid API token
-```
+- deploy 自体は完了している可能性があります。
+- Step Summary と Cloudflare Pages dashboard の deployment URL を確認してください。
 
-#### 解決策
-1. Cloudflare API トークンを再確認
-2. 権限が正しく設定されているか確認
-3. アカウント ID が正しいか確認
+### ロールバックしたい
 
-```bash
-# GitHub Secrets を確認
-Settings → Secrets and variables → Actions
-→ CLOUDFLARE_API_TOKEN
-→ CLOUDFLARE_ACCOUNT_ID
-```
+最短経路は、問題を起こした commit を `main` で revert し、`Deploy to Cloudflare Pages` を再度走らせることです。
 
----
+- アプリコードの rollback: revert commit を `main` に push する
+- CSV / JSON 変更を含む rollback: revert 後に `sync-json-data.yml` が期待通り `data/akyo-data-*.json` と R2 を戻しているか確認する
 
-### TypeScript エラー
+### `npm run push:check-pr` が失敗した
 
-#### 症状
-```
-error TS2307: Cannot find module 'next' or its corresponding type declarations.
-```
+- `2`: PR conflict を解消する
+- `4`: 少し待って再実行する
+- `5`: その branch は既に merged PR に紐づいているので、新しい branch を切る
 
-#### 解決策
-```bash
-# 型定義を再インストール
-npm install --save-dev @types/node @types/react @types/react-dom
-```
+### `Validate Cloudflare Resources` の CSV step だけ失敗した
+
+- まず workflow が legacy CSV path を見ていないか確認してください。
+- 現状は `data/akyo-data.csv` / `data/akyo-data-US.csv` を前提としているため、repo 側の実ファイル名と一致しません。
 
 ---
 
-### セキュリティ監査で脆弱性が見つかった
-
-#### 対応手順
-
-1. **脆弱性の確認**
-   ```bash
-   npm audit
-   ```
-
-2. **自動修正を試す**
-   ```bash
-   npm audit fix
-   ```
-
-3. **手動更新が必要な場合**
-   ```bash
-   npm update package-name
-   ```
-
-4. **破壊的変更がある場合**
-   - CHANGELOG を確認
-   - テストを実行
-   - 段階的にアップデート
-
----
-
-### R2/KV バリデーションが失敗する
-
-#### 症状
-```
-Could not list R2 buckets - check API token permissions
-```
-
-#### 解決策
-1. API トークンに以下の権限があるか確認：
-   - Account → Workers R2 Storage → Read
-   - Account → Workers KV Storage → Read
-
-2. wrangler.toml の設定を確認
-   ```toml
-   name = "akyodex"
-   compatibility_date = "2025-01-22"
-   ```
-
-3. Cloudflare ダッシュボードでリソースが存在するか確認
-
----
-
-### CI が遅い
-
-#### 最適化方法
-
-1. **キャッシュの活用**
-   ```yaml
-   - uses: actions/cache@v4
-     with:
-       path: node_modules
-       key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
-   ```
-
-2. **並列実行**
-   - 依存関係のないジョブは並列実行
-   - `needs:` を適切に設定
-
-3. **不要なジョブをスキップ**
-   ```yaml
-   if: github.event_name == 'pull_request'
-   ```
-
----
-
-## REST API の考え方に基づいた設計
-
-### リソース指向のワークフロー
-
-このワークフローは、REST API の原則に従って設計されています：
-
-1. **リソースの明確な定義**
-   - ビルド成果物 (Build Artifacts)
-   - デプロイメント (Deployments)
-   - セキュリティレポート (Security Reports)
-   - リソース検証 (Resource Validations)
-
-2. **ステートレスな処理**
-   - 各ワークフローは独立して実行可能
-   - 前回の実行状態に依存しない
-
-3. **再利用可能なコンポーネント**
-   - `reusable-build.yml` で共通ロジックを抽出
-   - DRY 原則に従った設計
-
-4. **適切な HTTP メソッドに対応**
-   - GET: 情報取得 (セキュリティ監査、リソース検証)
-   - POST: リソース作成 (ビルド、デプロイ)
-   - PUT: リソース更新 (再デプロイ)
-
----
-
-## まとめ
-
-このワークフローセットは、以下の原則に基づいて設計されています：
-
-✅ **DRY (Don't Repeat Yourself)**: 共通ロジックを再利用可能なワークフローに抽出
-✅ **REST API の考え方**: リソース指向、ステートレス、再利用可能
-✅ **Next.js 15 ベストプラクティス**: App Router、Edge Runtime、ISR
-✅ **Tailwind CSS 最適化**: 適切なビルド設定
-✅ **Cloudflare Pages 最適化**: OpenNext、R2、KV の活用
-✅ **セキュリティ**: CodeQL、npm audit、定期監査
-✅ **パフォーマンス**: キャッシング、並列実行、最適化されたビルド
-
----
-
-**最終更新**: 2025-11-07
-**対応バージョン**: Next.js 15.5.2, Tailwind CSS 4.x, @opennextjs/cloudflare 1.11.0
+**最終更新**: 2026-03-07  
+**対象実装**: `.github/workflows/*.yml`, `scripts/push-and-check-pr-conflicts.js`, `open-next.config.ts`, `scripts/prepare-cloudflare-pages.js`

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ npm install
 ```
 
 ### Step 2: Set Up Environment (1 minute)
+
+The example below uses Bash heredoc syntax. On PowerShell, create `.env.local` manually and paste the same key/value pairs.
+
 ```bash
 # Create .env.local file with default credentials
 cat > .env.local << 'EOF'
@@ -381,6 +384,8 @@ Akyodex/
 
 ### Installation
 
+The example below uses Bash heredoc syntax. On PowerShell, create `.env.local` manually and paste the same key/value pairs.
+
 ```bash
 # Clone repository
 git clone https://github.com/rad-vrc/Akyodex.git
@@ -447,194 +452,117 @@ npm run data:convert     # Convert CSV to JSON (npx tsx scripts/csv-to-json.ts)
 
 ## 🚀 Deployment Guide
 
-### Cloudflare Pages Setup
+### Current Deployment Model
 
-#### 1. Create Cloudflare Pages Project
+- `npm run build` runs `opennextjs-cloudflare build` and then `scripts/prepare-cloudflare-pages.js`, which reshapes `.open-next` for Pages (`_worker.js`, `_routes.json`, and root-level static assets).
+- `open-next.config.ts` stores incremental cache in R2, tag cache in KV, uses `queue: 'direct'`, and enables cache interception for Pages.
+- `push` to `main` triggers `.github/workflows/deploy-cloudflare-pages.yml`.
+- Non-draft PRs targeting `main` or `develop` are checked by `.github/workflows/cloudflare-pages-preview-gate.yml`.
+
+### 1. Create Cloudflare Pages Project
 
 Via Cloudflare Dashboard:
 1. Go to Cloudflare Dashboard → Pages
 2. Create a new project
 3. Connect to GitHub repository: `rad-vrc/Akyodex`
 
-#### 2. Build Configuration
+### 2. Build Configuration
 
 ```yaml
 Framework preset: None
 Build command: npm ci && npm run build
 Build output directory: .open-next
-Root directory: /  (repository root)
+Root directory: /
 ```
 
-#### 3. Environment Variables
-
-Go to **Settings** → **Environment variables** and add:
-
-```bash
-# Admin Authentication (plaintext - compared server-side)
-ADMIN_PASSWORD_OWNER=your_owner_password
-ADMIN_PASSWORD_ADMIN=your_admin_password
-
-# Session Secret (generate with: openssl rand -hex 64)
-SESSION_SECRET=your_128_char_hex_secret
-
-# App URL
-NEXT_PUBLIC_APP_URL=https://akyodex.com
-NEXT_PUBLIC_R2_BASE=https://images.akyodex.com
-
-# GitHub integration (for CSV sync)
-GITHUB_TOKEN=ghp_xxx
-GITHUB_REPO_OWNER=rad-vrc
-GITHUB_REPO_NAME=Akyodex
-GITHUB_BRANCH=main
-GITHUB_CSV_PATH_JA=data/akyo-data-ja.csv
-```
-
-#### 4. Cloudflare Bindings
+### 3. Required Cloudflare Bindings
 
 Bindings are defined in `wrangler.toml` and configured in **Settings** → **Functions**:
 
-```toml
-# R2 Bucket Binding
-[[r2_buckets]]
-binding = "AKYO_BUCKET"
-bucket_name = "akyo-images"
+| Binding | Type | Purpose | Notes |
+| ------- | ---- | ------- | ----- |
+| `AKYO_BUCKET` | R2 Bucket | Avatar images and `data/*.json` / CSV files | Usually points to `akyo-images` |
+| `NEXT_INC_CACHE_R2_BUCKET` | R2 Bucket | OpenNext incremental cache | Keys are namespaced under `incremental-cache/...` |
+| `AKYO_KV` | KV Namespace | Admin sessions + app data cache | App cache keys use `akyo-data:<locale>` |
+| `NEXT_TAG_CACHE_KV` | KV Namespace | OpenNext tag revalidation cache | Tag keys use `<NEXT_BUILD_ID>/<tag>` |
 
-# KV Namespace Binding
-[[kv_namespaces]]
-binding = "AKYO_KV"
-id = "your_kv_namespace_id"
-```
+`AKYO_BUCKET` と `NEXT_INC_CACHE_R2_BUCKET` は同じ bucket を共有できます。`AKYO_KV` と `NEXT_TAG_CACHE_KV` も同じ namespace を共有できますが、キー体系が重ならないことを確認してください。
 
-#### 5. Create R2 Bucket
+### 4. Runtime Secrets and Variables (Cloudflare Pages)
 
-```bash
-# Create R2 bucket
-npx wrangler r2 bucket create akyo-images
+Go to **Settings** → **Environment variables** and add:
 
-# Upload CSV files
-npx wrangler r2 object put akyo-images/data/akyo-data-ja.csv --file=data/akyo-data-ja.csv
-npx wrangler r2 object put akyo-images/data/akyo-data-en.csv --file=data/akyo-data-en.csv
-```
+| Variable | Required | Purpose |
+| -------- | -------- | ------- |
+| `ADMIN_PASSWORD_OWNER` | Yes | Owner role login code (`src/app/api/admin/login/route.ts`) |
+| `ADMIN_PASSWORD_ADMIN` | Yes | Admin role login code (`src/app/api/admin/login/route.ts`) |
+| `SESSION_SECRET` | Yes | HMAC session signing key (`src/lib/session.ts`) |
+| `NEXT_PUBLIC_APP_URL` | Yes | CSRF allowlist origin (`src/lib/api-helpers.ts`) |
+| `NEXT_PUBLIC_R2_BASE` | Yes | Public base URL for R2-hosted images/data |
+| `GITHUB_TOKEN` | Yes | CSV sync and admin-side GitHub writes |
+| `GITHUB_REPO_OWNER` | Yes | GitHub repo owner for CSV sync |
+| `GITHUB_REPO_NAME` | Yes | GitHub repo name for CSV sync |
+| `GITHUB_BRANCH` | Yes | Target branch for CSV sync |
+| `GITHUB_CSV_PATH_JA` | Yes | JA CSV path in repo |
+| `REVALIDATE_SECRET` | Recommended | Protects `/api/revalidate` |
+| `NEXT_PUBLIC_DIFY_CHATBOT_TOKEN` | Optional | Enables Dify/Udify chatbot widget |
 
-#### 6. Create KV Namespace
+### 5. GitHub Actions Secrets and Variables
 
-```bash
-# Create KV namespace for sessions and data cache
-npx wrangler kv:namespace create "AKYO_KV"
+These are for GitHub-hosted workflows, not for the runtime app itself:
 
-# Copy the ID and update wrangler.toml
-```
+| Name | Required | Used by | Notes |
+| ---- | -------- | ------- | ----- |
+| `CLOUDFLARE_API_TOKEN` | Yes | Deploy + Preview Gate | Must be able to deploy Pages and inspect deployments |
+| `CLOUDFLARE_ACCOUNT_ID` | Yes | Deploy + Preview Gate | Cloudflare account identifier |
+| `CLOUDFLARE_PAGES_PROJECT` | Recommended | Deploy + Preview Gate | Primary Pages project candidate; Preview Gate falls back to `akyodex` |
+| `NEXT_PUBLIC_SITE_URL` | Optional | Build workflows | Build-time public URL fallback |
+| `NEXT_PUBLIC_R2_BASE` | Optional | Build workflows | Build-time R2 URL fallback |
+| `R2_ACCESS_KEY_ID` | Optional | `sync-json-data.yml` | Required when JSON sync uploads to R2 |
+| `R2_SECRET_ACCESS_KEY` | Optional | `sync-json-data.yml` | Required when JSON sync uploads to R2 |
+| `DEFAULT_ADMIN_PASSWORD_HASH` | Optional / legacy | Build workflows only | Legacy fallback still exported by workflow YAML |
+| `DEFAULT_OWNER_PASSWORD_HASH` | Optional / legacy | Build workflows only | Legacy fallback still exported by workflow YAML |
+| `DEFAULT_JWT_SECRET` | Optional / legacy | Build workflows only | Legacy fallback still exported by workflow YAML |
 
-#### 7. Deploy
+The current runtime code reads `ADMIN_PASSWORD_OWNER`, `ADMIN_PASSWORD_ADMIN`, and `SESSION_SECRET`. The `*_HASH` / `DEFAULT_JWT_SECRET` values above are workflow-side compatibility defaults and are not read by `src/app/api/admin/login/route.ts` or `src/lib/session.ts`.
 
-Push to `main` branch for automatic deployment.
+### 6. Deployment Paths
+
+- **Production deploy**: push or merge to `main` → `deploy-cloudflare-pages.yml`
+- **Manual deploy**: Actions → `Deploy to Cloudflare Pages` → choose `production` or `staging`
+- **PR preview verification**: `cloudflare-pages-preview-gate.yml` polls the Cloudflare Pages API and falls back to the GitHub check run named `Cloudflare Pages` when Cloudflare omits commit metadata
+
+PR preview と production/manual deploy は source of truth が異なります。PR preview は Cloudflare Pages の Git-connected preview を監視し、production/manual deploy は GitHub Actions + `wrangler pages deploy` が本線です。
 
 ---
 
 ## ✅ Deployment Verification
 
-**After successful deployment, verify everything is working correctly:**
+### Fast Checks After `main` Deploy
 
-### 1. Build Success Check
+| Check | Where | Expected Result |
+| ----- | ----- | --------------- |
+| Deploy summary | GitHub Actions `Deploy to Cloudflare Pages` | `Deploy Step: success` and `Health Check: healthy` |
+| Deployment URL | Workflow output / Step Summary | URL is present and responds with `200`, `301`, or `302` within the health-check retry window |
+| Core routes | `/`, `/zukan`, `/admin` | Landing redirect works, gallery loads, admin login page renders |
+| Static/PWA assets | `/manifest.webmanifest`, `/sw.js` | Assets return successfully |
+| Cloudflare bindings | Pages dashboard or `wrangler.toml` | All four bindings (`AKYO_BUCKET`, `NEXT_INC_CACHE_R2_BUCKET`, `AKYO_KV`, `NEXT_TAG_CACHE_KV`) are present |
+| Admin flow | `/admin` | Login succeeds and session cookie is set |
+| Data plane | `https://images.akyodex.com/data/*.json` | Latest JSON is reachable after data sync |
 
-```bash
-# In Cloudflare Pages Dashboard
-✅ Build status: Success
-✅ Deployment URL: https://your-project.pages.dev
-✅ No build errors in logs
-```
+### PR Preview Gate Checks
 
-### 2. Basic Functionality Test
+1. Open a non-draft PR against `main` or `develop`.
+2. Confirm `Cloudflare Pages Preview Gate / Verify Cloudflare Pages Preview` succeeds.
+3. If Cloudflare's deployment API does not return commit metadata, confirm the fallback GitHub check run named `Cloudflare Pages` completed successfully.
+4. If the gate times out, check `CLOUDFLARE_PAGES_PROJECT`, the Cloudflare preview deployment logs, and the GitHub Actions run logs together.
 
-| Feature | URL | Expected Result |
-|---------|-----|----------------|
-| **Landing Page** | `https://your-project.pages.dev/` | Redirects to /zukan |
-| **Avatar Gallery** | `https://your-project.pages.dev/zukan` | Shows avatars |
-| **Admin Login** | `https://your-project.pages.dev/admin` | Login page loads |
-| **Language Switch** | Click language toggle | Switches between 日本語/English |
-| **PWA Manifest** | `https://your-project.pages.dev/manifest.webmanifest` | JSON file loads |
-| **Service Worker** | `https://your-project.pages.dev/sw.js` | JavaScript file loads |
+### Known Limitations
 
-### 3. Cloudflare Bindings Check
-
-```bash
-# Check R2 bucket
-npx wrangler r2 bucket list
-# Should show: akyo-images
-
-npx wrangler r2 object list akyo-images
-# Should show: data/akyo-data-ja.csv, data/akyo-data-en.csv, images/
-
-# Check KV namespace
-npx wrangler kv:namespace list
-# Should show: AKYO_KV with ID
-```
-
-### 4. Admin Panel Test
-
-| Tab | Action | Expected Result |
-|-----|--------|----------------|
-| **Add** | Fetch next ID | Shows next available 4-digit ID |
-| **Add** | VRChat fetch | Retrieves avatar/world info from VRChat URL |
-| **Edit** | Search entry | Finds existing entry |
-| **Edit** | Update field | Saves changes to CSV (synced to GitHub) |
-| **Tools** | View categories | Shows all category tags |
-
-### 5. PWA Installation Test
-
-```bash
-# Desktop (Chrome/Edge):
-# 1. Visit site in browser
-# 2. Look for install icon in address bar
-# 3. Click "Install" → Should install as desktop app
-
-# Mobile (Android/iOS):
-# 1. Visit site in browser
-# 2. Menu → "Add to Home Screen"
-# 3. Should add app icon to home screen
-```
-
-### 6. Performance Check
-
-```bash
-# Run Lighthouse audit (Chrome DevTools)
-# Expected scores:
-```
-
-- **Performance**: 90+ (green)
-- **Accessibility**: 95+ (green)
-- **Best Practices**: 90+ (green)
-- **SEO**: 90+ (green)
-- **PWA**: ✅ Installable
-
-### 7. Error Monitoring
-
-```bash
-# Check Cloudflare Pages Dashboard:
-✅ Functions → No errors in last 24h
-✅ Analytics → Requests succeeding
-✅ Logs → No 5xx errors
-```
-
-### Troubleshooting Failed Checks
-
-If any check fails, see [Troubleshooting](#troubleshooting) section for detailed solutions.
-
-**Quick fixes:**
-- Build fails → Check Root directory setting
-- 404 errors → Check Build output directory
-- API errors → Check Environment variables
-- Bindings not working → Check Settings → Functions
-
-### Cloudflare Pages Preview Gate limitation (fork PRs)
-
-The workflow `.github/workflows/cloudflare-pages-preview-gate.yml` has two steps:
-- `Validate required secrets`
-- `Skip gate for forked PRs`
-
-For forked PRs, `CF_API_TOKEN` and `CF_ACCOUNT_ID` are unavailable by design, so the preview verification is skipped.
-If you need strict verification for forked PRs as well, do not rely only on this workflow as a required status check.
-Use an alternative trusted-branch approach (for example, a secrets-dependent job that runs after maintainers push to a protected branch).
+- **Fork PRs**: Cloudflare secrets are unavailable by design, so Preview Gate is skipped for forked PRs.
+- **Project resolution**: Preview Gate checks `vars.CLOUDFLARE_PAGES_PROJECT` first and then falls back to `akyodex`.
+- **Missing deploy URL**: If deploy succeeds but the action does not return a URL, the workflow records `missing_url` and skips HTTP verification. Use the Pages dashboard URL in that case.
+- **Manual `staging` runs**: the workflow input only changes the GitHub Actions environment label. If you want true staging isolation, you must also provision separate Pages project / bindings / secrets.
 
 ---
 
@@ -671,17 +599,37 @@ Use an alternative trusted-branch approach (for example, a secrets-dependent job
 | `GITHUB_CSV_PATH_JA` | Japanese CSV path in repo | `data/akyo-data-ja.csv` |
 | `REVALIDATE_SECRET` | ISR revalidation API key | *(secret)* |
 
+#### GitHub Actions / CI-CD
+
+| Variable / Secret | Description | Example |
+| ----------------- | ----------- | ------- |
+| `CLOUDFLARE_API_TOKEN` | GitHub Actions から Pages deploy / preview を操作する API token | *(secret)* |
+| `CLOUDFLARE_ACCOUNT_ID` | Cloudflare account ID | *(secret)* |
+| `CLOUDFLARE_PAGES_PROJECT` | Preview Gate が最初に参照する Pages project 名 | `akyodex` |
+| `NEXT_PUBLIC_SITE_URL` | Workflow build-time fallback URL | `https://akyodex.com` |
+| `NEXT_PUBLIC_R2_BASE` | Workflow build-time fallback R2 base | `https://images.akyodex.com` |
+| `R2_ACCESS_KEY_ID` | `sync-json-data.yml` が R2 に JSON を upload するときの access key | *(secret)* |
+| `R2_SECRET_ACCESS_KEY` | `sync-json-data.yml` が R2 に JSON を upload するときの secret key | *(secret)* |
+| `DEFAULT_ADMIN_PASSWORD_HASH` | Legacy workflow fallback（runtime 未使用） | *(optional)* |
+| `DEFAULT_OWNER_PASSWORD_HASH` | Legacy workflow fallback（runtime 未使用） | *(optional)* |
+| `DEFAULT_JWT_SECRET` | Legacy workflow fallback（runtime 未使用） | *(optional)* |
+
+Current runtime code reads `ADMIN_PASSWORD_OWNER`, `ADMIN_PASSWORD_ADMIN`, `SESSION_SECRET`, and `NEXT_PUBLIC_APP_URL`. The `DEFAULT_*_HASH` / `DEFAULT_JWT_SECRET` values are only referenced by the current workflow YAML.
+
 ### Cloudflare Bindings (wrangler.toml)
 
 | Binding | Type | Purpose |
-|---------|------|---------|
+| ------- | ---- | ------- |
 | `AKYO_BUCKET` | R2 Bucket | Avatar images and data files |
+| `NEXT_INC_CACHE_R2_BUCKET` | R2 Bucket | OpenNext incremental cache |
 | `AKYO_KV` | KV Namespace | Admin session storage + data cache |
 | `NEXT_TAG_CACHE_KV` | KV Namespace | OpenNext tag revalidation cache |
 
 `AKYO_KV` と `NEXT_TAG_CACHE_KV` を同じ namespace に割り当てる場合は、キー体系が重ならないことを確認してください。
 - App data cache keys: `akyo-data:ja`, `akyo-data:en` (pattern: `akyo-data:<locale>`)
 - OpenNext tag cache keys: `<NEXT_BUILD_ID>/<tag>`
+
+`AKYO_BUCKET` と `NEXT_INC_CACHE_R2_BUCKET` を同じ bucket に割り当てる場合は、OpenNext incremental cache が `incremental-cache/...` 配下に保存される前提で、画像や `data/*.json` と衝突しない構成にしてください。
 
 ### How to Generate Session Secret
 
@@ -1312,10 +1260,17 @@ git add .
 git commit -m "feat: description of changes"
 
 # 3. Push to remote
-git push origin feature/your-feature-name
+git push -u origin feature/your-feature-name
+
+# PowerShell in this repo automatically runs the PR conflict check after push.
+# Use this instead of plain git push in other shells:
+npm run push:check-pr -- -u origin HEAD
 
 # 4. Create Pull Request on GitHub
 ```
+
+If the push check exits with code `5`, the branch already has a merged PR and you should continue on a new branch / PR.
+Exit code `2` means the open PR has merge conflicts, and exit code `4` means GitHub has not finished calculating mergeability yet.
 
 ### Commit Message Convention
 
@@ -1341,8 +1296,9 @@ chore: Update dependencies
 
 1. ✅ Run `npm run lint`
 2. ✅ Run `npm run build` (includes type checking)
-3. ✅ Test locally with `npm run dev`
-4. ✅ Write descriptive PR description
+3. ✅ If needed, re-run `npm run push:check-pr -- --skip-push` to confirm the branch PR is still mergeable
+4. ✅ Test locally with `npm run dev`
+5. ✅ Write descriptive PR description with deploy/test notes
 
 ---
 
@@ -1371,6 +1327,6 @@ For questions or issues:
 
 ---
 
-**Last Updated**: 2026-02-13  
+**Last Updated**: 2026-03-07  
 **Status**: ✅ Production Ready
 


### PR DESCRIPTION
## Summary
- align `README.md` with the current Cloudflare Pages preview, deploy, and PR conflict-check automation
- rewrite `.github/workflows/README.md` around the live workflow YAML, including preview-gate fallback behavior, staging caveats, rollback guidance, and known workflow drift
- document contributor setup notes such as PowerShell `.env.local` creation, R2 JSON sync secrets, and fork PR limitations

## Test plan
- [x] Cross-checked `README.md` against `deploy-cloudflare-pages.yml`, `cloudflare-pages-preview-gate.yml`, `wrangler.toml`, `scripts/push-and-check-pr-conflicts.js`, and runtime env usage
- [x] Cross-checked `.github/workflows/README.md` against the current workflow YAML files
- [x] Verified `.github/workflows/README.md` has no markdownlint diagnostics in the editor
- [ ] No runtime tests executed (docs-only change)