### PR TITLE
fix: preserve favorites and harden admin validation

### DIFF
--- a/src/components/admin/edit-modal.tsx
+++ b/src/components/admin/edit-modal.tsx
@@ -9,6 +9,7 @@ import {
   extractVRChatAvatarIdFromUrl,
   getAkyoSourceUrl,
   resolveDisplaySerialForSourceUrlChange,
+  shouldResetWorldMetadata,
 } from '@/lib/akyo-entry';
 import type { AkyoData } from '@/types/akyo';
 import { FormEvent, useEffect, useRef, useState } from 'react';
@@ -315,6 +316,9 @@ export function EditModal({
       sourceUrl: value,
       avatarUrl: value,
       entryType: detectedEntryType ?? prev.entryType,
+      ...(shouldResetWorldMetadata(prev.sourceUrl, value)
+        ? { nickname: '', author: '' }
+        : {}),
       displaySerial: resolveDisplaySerialForSourceUrlChange({
         currentDisplaySerial: prev.displaySerial,
         detectedEntryType,

--- a/src/components/admin/tabs/add-tab.tsx
+++ b/src/components/admin/tabs/add-tab.tsx
@@ -8,6 +8,7 @@ import {
   ensureWorldCategory,
   extractVRChatAvatarIdFromUrl,
   extractVRChatWorldIdFromUrl,
+  shouldResetWorldMetadata,
 } from '@/lib/akyo-entry';
 import { assertWorldRegistrationAssets } from '@/lib/world-registration';
 import { FormEvent, useCallback, useEffect, useRef, useState } from 'react';
@@ -92,15 +93,6 @@ function normalizeCategoriesForSubmit(
   return entryType === 'world'
     ? ensureWorldCategory(normalized)
     : Array.from(new Set(normalized));
-}
-
-function shouldResetWorldMetadata(previousUrl: string, nextUrl: string): boolean {
-  const previousType = detectVrcEntryTypeFromUrl(previousUrl);
-  const nextType = detectVrcEntryTypeFromUrl(nextUrl);
-  if (nextType !== 'world') {
-    return false;
-  }
-  return previousUrl.trim() !== nextUrl.trim() || previousType !== 'world';
 }
 
 /**

--- a/src/hooks/use-akyo-data.test.ts
+++ b/src/hooks/use-akyo-data.test.ts
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import * as useAkyoDataModuleNs from "./use-akyo-data";
+
+const useAkyoDataModule =
+  (useAkyoDataModuleNs as { default?: Record<string, unknown> }).default ??
+  (useAkyoDataModuleNs as Record<string, unknown>);
+
+const applyFavoriteOverrides = useAkyoDataModule.applyFavoriteOverrides as
+  | ((persistedFavoriteIds: readonly string[], overrides: Record<string, boolean>) => string[])
+  | undefined;
+const pruneFavoriteOverrides = useAkyoDataModule.pruneFavoriteOverrides as
+  | ((persistedFavoriteIds: readonly string[], overrides: Record<string, boolean>) => Record<string, boolean>)
+  | undefined;
+const reconcileFavoriteOverride = useAkyoDataModule.reconcileFavoriteOverride as
+  | ((args: {
+      persistedFavoriteIds: readonly string[];
+      overrides: Record<string, boolean>;
+      id: string;
+      nextIsFavorite: boolean;
+    }) => Record<string, boolean>)
+  | undefined;
+const syncFavoriteCollections = useAkyoDataModule.syncFavoriteCollections as
+  | ((args: {
+      data: Array<{ id: string; isFavorite?: boolean }>;
+      filteredData: Array<{ id: string; isFavorite?: boolean }>;
+      favoriteIds: readonly string[];
+    }) => {
+      nextData: Array<{ id: string; isFavorite?: boolean }>;
+      nextFilteredData: Array<{ id: string; isFavorite?: boolean }>;
+    })
+  | undefined;
+const getNextFavoritePersistRetryDelayMs =
+  useAkyoDataModule.getNextFavoritePersistRetryDelayMs as
+    | ((previousDelayMs: number | null) => number)
+    | undefined;
+
+test("applyFavoriteOverrides keeps pending local favorites on top of fresher storage data", () => {
+  assert.equal(typeof applyFavoriteOverrides, "function");
+
+  assert.deepEqual(
+    applyFavoriteOverrides?.(["0001", "0003"], { "0002": true }),
+    ["0001", "0002", "0003"],
+  );
+});
+
+test("pruneFavoriteOverrides clears overrides once storage already matches the desired state", () => {
+  assert.equal(typeof pruneFavoriteOverrides, "function");
+
+  assert.deepEqual(
+    pruneFavoriteOverrides?.([], { "0001": false }),
+    {},
+  );
+  assert.deepEqual(
+    pruneFavoriteOverrides?.(["0002"], { "0002": true }),
+    {},
+  );
+});
+
+test("reconcileFavoriteOverride stores only differences from the persisted favorites", () => {
+  assert.equal(typeof reconcileFavoriteOverride, "function");
+
+  assert.deepEqual(
+    reconcileFavoriteOverride?.({
+      persistedFavoriteIds: ["0001"],
+      overrides: {},
+      id: "0001",
+      nextIsFavorite: true,
+    }),
+    {},
+  );
+
+  assert.deepEqual(
+    reconcileFavoriteOverride?.({
+      persistedFavoriteIds: ["0001"],
+      overrides: {},
+      id: "0001",
+      nextIsFavorite: false,
+    }),
+    { "0001": false },
+  );
+});
+
+test("syncFavoriteCollections updates data and filtered views from the same effective favorites", () => {
+  assert.equal(typeof syncFavoriteCollections, "function");
+
+  const result = syncFavoriteCollections?.({
+    data: [
+      { id: "0001", isFavorite: false },
+      { id: "0002", isFavorite: false },
+    ],
+    filteredData: [{ id: "0001", isFavorite: false }],
+    favoriteIds: ["0001"],
+  });
+
+  assert.deepEqual(result?.nextData.map(({ id, isFavorite }) => ({ id, isFavorite })), [
+    { id: "0001", isFavorite: true },
+    { id: "0002", isFavorite: false },
+  ]);
+  assert.deepEqual(
+    result?.nextFilteredData.map(({ id, isFavorite }) => ({ id, isFavorite })),
+    [{ id: "0001", isFavorite: true }],
+  );
+});
+
+test("getNextFavoritePersistRetryDelayMs backs off and caps retries", () => {
+  assert.equal(typeof getNextFavoritePersistRetryDelayMs, "function");
+
+  assert.equal(getNextFavoritePersistRetryDelayMs?.(null), 1000);
+  assert.equal(getNextFavoritePersistRetryDelayMs?.(1000), 2000);
+  assert.equal(getNextFavoritePersistRetryDelayMs?.(16000), 30000);
+  assert.equal(getNextFavoritePersistRetryDelayMs?.(30000), 30000);
+});

--- a/src/hooks/use-akyo-data.ts
+++ b/src/hooks/use-akyo-data.ts
@@ -11,6 +11,9 @@ import { useCallback, useEffect, useRef, useState } from "react";
 /** localStorage のキー名 */
 const FAVORITES_STORAGE_KEY = "akyoFavorites";
 const MULTI_VALUE_SPLIT_PATTERN = /[、,]/;
+const FAVORITE_PERSIST_RETRY_BASE_DELAY_MS = 1000;
+const FAVORITE_PERSIST_RETRY_MAX_DELAY_MS = 30000;
+export type FavoriteOverrides = Record<string, boolean>;
 
 function toHiragana(value: string): string {
   return value.replace(/[\u30A1-\u30F6]/g, (char) =>
@@ -46,18 +49,79 @@ export function useAkyoData(initialData: AkyoData[] = []) {
   const [filteredData, setFilteredData] = useState<AkyoData[]>(initialData);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const dataRef = useRef<AkyoData[]>(initialData);
+  const filteredDataRef = useRef<AkyoData[]>(initialData);
   const favoritesDirtyRef = useRef(false);
+  const favoriteOverridesRef = useRef<FavoriteOverrides>({});
+  const favoritePersistRetryTimeoutRef = useRef<number | null>(null);
+  const favoritePersistRetryDelayRef = useRef<number | null>(null);
   const lastPersistedFavoritesRef = useRef<string | null>(null);
+  const [favoritePersistRetryNonce, setFavoritePersistRetryNonce] = useState(0);
+
+  const clearFavoritePersistRetry = useCallback(() => {
+    if (favoritePersistRetryTimeoutRef.current !== null) {
+      window.clearTimeout(favoritePersistRetryTimeoutRef.current);
+      favoritePersistRetryTimeoutRef.current = null;
+    }
+    favoritePersistRetryDelayRef.current = null;
+  }, []);
+
+  const scheduleFavoritePersistRetry = useCallback(() => {
+    if (typeof window === "undefined") return;
+
+    if (favoritePersistRetryTimeoutRef.current !== null) {
+      window.clearTimeout(favoritePersistRetryTimeoutRef.current);
+    }
+
+    const nextDelay = getNextFavoritePersistRetryDelayMs(
+      favoritePersistRetryDelayRef.current,
+    );
+    favoritePersistRetryDelayRef.current = nextDelay;
+    favoritePersistRetryTimeoutRef.current = window.setTimeout(() => {
+      favoritePersistRetryTimeoutRef.current = null;
+      setFavoritePersistRetryNonce((prev) => prev + 1);
+    }, nextDelay);
+  }, []);
+
+  useEffect(() => {
+    dataRef.current = data;
+  }, [data]);
+
+  useEffect(() => {
+    filteredDataRef.current = filteredData;
+  }, [filteredData]);
+
+  useEffect(
+    () => () => {
+      clearFavoritePersistRetry();
+    },
+    [clearFavoritePersistRetry],
+  );
 
   // クライアントサイドでお気に入り情報を復元
   useEffect(() => {
     if (initialData.length > 0) {
-      const dataWithFavorites = applyFavorites(initialData);
+      const persistedFavorites = getFavorites();
+      favoriteOverridesRef.current = pruneFavoriteOverrides(
+        persistedFavorites,
+        favoriteOverridesRef.current,
+      );
+      const dataWithFavorites = applyFavoritesFromIds(
+        initialData,
+        applyFavoriteOverrides(
+          persistedFavorites,
+          favoriteOverridesRef.current,
+        ),
+      );
       // eslint-disable-next-line react-hooks/set-state-in-effect
+      dataRef.current = dataWithFavorites;
+      filteredDataRef.current = dataWithFavorites;
       setData(dataWithFavorites);
       setFilteredData(dataWithFavorites);
       // 初期復元時点の基準値を記録して、将来の差分判定を安定化させる
-      lastPersistedFavoritesRef.current = JSON.stringify(getFavorites());
+      lastPersistedFavoritesRef.current = JSON.stringify(persistedFavorites);
+      favoritesDirtyRef.current =
+        Object.keys(favoriteOverridesRef.current).length > 0;
     }
   }, [initialData]);
 
@@ -67,11 +131,28 @@ export function useAkyoData(initialData: AkyoData[] = []) {
       if (e.key !== FAVORITES_STORAGE_KEY) return;
       // キャッシュを無効化して最新の値を取得
       invalidateFavoritesCache();
+      const persistedFavorites = getFavorites();
+      favoriteOverridesRef.current = pruneFavoriteOverrides(
+        persistedFavorites,
+        favoriteOverridesRef.current,
+      );
+      const effectiveFavorites = applyFavoriteOverrides(
+        persistedFavorites,
+        favoriteOverridesRef.current,
+      );
       // 別タブ更新を基準値として取り込み、次回の差分判定を正しくする
-      lastPersistedFavoritesRef.current = JSON.stringify(getFavorites());
-      favoritesDirtyRef.current = false;
-      setData((prev) => applyFavorites(prev));
-      setFilteredData((prev) => applyFavorites(prev));
+      lastPersistedFavoritesRef.current = JSON.stringify(persistedFavorites);
+      favoritesDirtyRef.current =
+        Object.keys(favoriteOverridesRef.current).length > 0;
+      const { nextData, nextFilteredData } = syncFavoriteCollections({
+        data: dataRef.current,
+        filteredData: filteredDataRef.current,
+        favoriteIds: effectiveFavorites,
+      });
+      dataRef.current = nextData;
+      filteredDataRef.current = nextFilteredData;
+      setData(nextData);
+      setFilteredData(nextFilteredData);
     };
     window.addEventListener("storage", handleStorageChange);
     return () => window.removeEventListener("storage", handleStorageChange);
@@ -79,7 +160,10 @@ export function useAkyoData(initialData: AkyoData[] = []) {
 
   // dataの変更に合わせてお気に入りIDを永続化（state updater内の副作用を回避）
   useEffect(() => {
-    if (!favoritesDirtyRef.current) return;
+    if (!favoritesDirtyRef.current) {
+      clearFavoritePersistRetry();
+      return;
+    }
 
     // ここでの早期 return は dirty フラグを意図的に残し、データ同期後に再判定するため
     // saveFavorites / lastPersistedFavoritesRef / favoritesDirtyRef の更新は
@@ -91,25 +175,58 @@ export function useAkyoData(initialData: AkyoData[] = []) {
     );
     if (!hasFullySyncedFavoriteState) return;
 
-    const favorites = data
-      .filter((item) => item.isFavorite)
-      .map((item) => item.id);
-    const serializedFavorites = JSON.stringify(favorites);
-    if (serializedFavorites === lastPersistedFavoritesRef.current) {
+    const persistedFavorites = getFavorites();
+    favoriteOverridesRef.current = pruneFavoriteOverrides(
+      persistedFavorites,
+      favoriteOverridesRef.current,
+    );
+
+    if (Object.keys(favoriteOverridesRef.current).length === 0) {
+      clearFavoritePersistRetry();
+      lastPersistedFavoritesRef.current = JSON.stringify(persistedFavorites);
       favoritesDirtyRef.current = false;
       return;
     }
 
-    saveFavorites(favorites);
+    const favorites = applyFavoriteOverrides(
+      persistedFavorites,
+      favoriteOverridesRef.current,
+    );
+    const serializedFavorites = JSON.stringify(favorites);
+    if (!saveFavorites(favorites)) {
+      scheduleFavoritePersistRetry();
+      return;
+    }
+
+    clearFavoritePersistRetry();
+    favoriteOverridesRef.current = {};
     lastPersistedFavoritesRef.current = serializedFavorites;
     favoritesDirtyRef.current = false;
-  }, [data]);
+  }, [
+    clearFavoritePersistRetry,
+    data,
+    favoritePersistRetryNonce,
+    scheduleFavoritePersistRetry,
+  ]);
 
   /**
    * 新しいデータでリフレッシュ（言語切り替え時などに使用）
    */
   const refetchWithNewData = useCallback((newData: AkyoData[]) => {
-    const dataWithFavorites = applyFavorites(newData);
+    const persistedFavorites = getFavorites();
+    favoriteOverridesRef.current = pruneFavoriteOverrides(
+      persistedFavorites,
+      favoriteOverridesRef.current,
+    );
+    const dataWithFavorites = applyFavoritesFromIds(
+      newData,
+      applyFavoriteOverrides(persistedFavorites, favoriteOverridesRef.current),
+    );
+    lastPersistedFavoritesRef.current = JSON.stringify(persistedFavorites);
+    favoritesDirtyRef.current =
+      Object.keys(favoriteOverridesRef.current).length > 0;
+    dataRef.current = dataWithFavorites;
+    filteredDataRef.current = dataWithFavorites;
     setData(dataWithFavorites);
     setFilteredData(dataWithFavorites);
   }, []);
@@ -226,6 +343,7 @@ export function useAkyoData(initialData: AkyoData[] = []) {
         });
       }
 
+      filteredDataRef.current = filtered;
       setFilteredData(filtered);
     },
     [data],
@@ -233,14 +351,34 @@ export function useAkyoData(initialData: AkyoData[] = []) {
 
   // お気に入り機能
   const toggleFavorite = useCallback((id: string) => {
-    const toggleFavoriteFlag = (items: AkyoData[]) =>
-      items.map((akyo) =>
-        akyo.id === id ? { ...akyo, isFavorite: !akyo.isFavorite } : akyo,
-      );
+    const currentData = dataRef.current;
+    const currentTarget = currentData.find((akyo) => akyo.id === id);
+    if (!currentTarget) return;
 
-    favoritesDirtyRef.current = true;
-    setData((prevData) => toggleFavoriteFlag(prevData));
-    setFilteredData((prevData) => toggleFavoriteFlag(prevData));
+    const persistedFavorites = getFavorites();
+    favoriteOverridesRef.current = reconcileFavoriteOverride({
+      persistedFavoriteIds: persistedFavorites,
+      overrides: favoriteOverridesRef.current,
+      id,
+      nextIsFavorite: !Boolean(currentTarget.isFavorite),
+    });
+
+    favoritesDirtyRef.current =
+      Object.keys(favoriteOverridesRef.current).length > 0;
+
+    const effectiveFavorites = applyFavoriteOverrides(
+      persistedFavorites,
+      favoriteOverridesRef.current,
+    );
+    const { nextData, nextFilteredData } = syncFavoriteCollections({
+      data: currentData,
+      filteredData: filteredDataRef.current,
+      favoriteIds: effectiveFavorites,
+    });
+    dataRef.current = nextData;
+    filteredDataRef.current = nextFilteredData;
+    setData(nextData);
+    setFilteredData(nextFilteredData);
   }, []);
 
   return {
@@ -284,8 +422,8 @@ function getFavorites(): string[] {
       Array.isArray(parsed) &&
       parsed.every((item): item is string => typeof item === "string")
     ) {
-      favoritesCache = parsed;
-      return parsed;
+      favoritesCache = normalizeFavoriteIds(parsed);
+      return favoritesCache;
     }
     // 不正なデータ形式の場合はリセット
     console.warn("Invalid favorites data in localStorage, resetting");
@@ -300,16 +438,16 @@ function getFavorites(): string[] {
 /**
  * お気に入りIDを保存（キャッシュも同時に更新）
  */
-function saveFavorites(ids: string[]): void {
-  // 防御的コピー: 呼び出し元による配列の変更からキャッシュを保護
-  const idsCopy = [...ids];
-  // キャッシュを先に更新してセッション内の一貫性を保つ
-  // (localStorage.setItem が容量超過等で失敗しても UI は正しく動作する)
-  favoritesCache = idsCopy;
+function saveFavorites(ids: string[]): boolean {
+  const idsCopy = normalizeFavoriteIds(ids);
   try {
     localStorage.setItem(FAVORITES_STORAGE_KEY, JSON.stringify(idsCopy));
+    favoritesCache = idsCopy;
+    return true;
   } catch (e) {
+    invalidateFavoritesCache();
     console.warn("Failed to save favorites to localStorage:", e);
+    return false;
   }
 }
 
@@ -318,8 +456,15 @@ function saveFavorites(ids: string[]): void {
  * Set を使用して O(1) ルックアップを実現 (React Best Practices 7.11)
  */
 function applyFavorites(items: AkyoData[]): AkyoData[] {
+  return applyFavoritesFromIds(items, getFavorites());
+}
+
+function applyFavoritesFromIds(
+  items: AkyoData[],
+  favoriteIds: readonly string[],
+): AkyoData[] {
   if (items.length === 0) return items;
-  const favoritesSet = new Set(getFavorites());
+  const favoritesSet = new Set(normalizeFavoriteIds(favoriteIds));
   return items.map((akyo) => ({
     ...akyo,
     parsedCategory:
@@ -330,6 +475,95 @@ function applyFavorites(items: AkyoData[]): AkyoData[] {
       parseMultiValueField(akyo.author || akyo.creator || ""),
     isFavorite: favoritesSet.has(akyo.id),
   }));
+}
+
+export function syncFavoriteCollections<T extends { id: string; isFavorite?: boolean }>(
+  args: {
+    data: readonly T[];
+    filteredData: readonly T[];
+    favoriteIds: readonly string[];
+  },
+): {
+  nextData: T[];
+  nextFilteredData: T[];
+} {
+  const { data, filteredData, favoriteIds } = args;
+  const favoritesSet = new Set(normalizeFavoriteIds(favoriteIds));
+  const applyFavoriteFlags = (items: readonly T[]) =>
+    items.map((item) => ({
+      ...item,
+      isFavorite: favoritesSet.has(item.id),
+    }));
+
+  return {
+    nextData: applyFavoriteFlags(data),
+    nextFilteredData: applyFavoriteFlags(filteredData),
+  };
+}
+
+function normalizeFavoriteIds(ids: readonly string[]): string[] {
+  return Array.from(new Set(ids.filter(Boolean))).sort((a, b) =>
+    a.localeCompare(b),
+  );
+}
+
+export function getNextFavoritePersistRetryDelayMs(
+  previousDelayMs: number | null,
+): number {
+  if (previousDelayMs === null) {
+    return FAVORITE_PERSIST_RETRY_BASE_DELAY_MS;
+  }
+
+  return Math.min(
+    previousDelayMs * 2,
+    FAVORITE_PERSIST_RETRY_MAX_DELAY_MS,
+  );
+}
+
+export function applyFavoriteOverrides(
+  persistedFavoriteIds: readonly string[],
+  overrides: FavoriteOverrides,
+): string[] {
+  const nextFavorites = new Set(normalizeFavoriteIds(persistedFavoriteIds));
+  for (const [id, isFavorite] of Object.entries(overrides)) {
+    if (isFavorite) {
+      nextFavorites.add(id);
+    } else {
+      nextFavorites.delete(id);
+    }
+  }
+  return normalizeFavoriteIds(Array.from(nextFavorites));
+}
+
+export function pruneFavoriteOverrides(
+  persistedFavoriteIds: readonly string[],
+  overrides: FavoriteOverrides,
+): FavoriteOverrides {
+  const persistedFavorites = new Set(normalizeFavoriteIds(persistedFavoriteIds));
+  return Object.fromEntries(
+    Object.entries(overrides).filter(
+      ([id, isFavorite]) => persistedFavorites.has(id) !== isFavorite,
+    ),
+  );
+}
+
+export function reconcileFavoriteOverride(args: {
+  persistedFavoriteIds: readonly string[];
+  overrides: FavoriteOverrides;
+  id: string;
+  nextIsFavorite: boolean;
+}): FavoriteOverrides {
+  const { persistedFavoriteIds, overrides, id, nextIsFavorite } = args;
+  const nextOverrides = { ...overrides };
+  const persistedFavorites = new Set(normalizeFavoriteIds(persistedFavoriteIds));
+
+  if (persistedFavorites.has(id) === nextIsFavorite) {
+    delete nextOverrides[id];
+  } else {
+    nextOverrides[id] = nextIsFavorite;
+  }
+
+  return pruneFavoriteOverrides(persistedFavoriteIds, nextOverrides);
 }
 
 function parseMultiValueField(value: string): string[] {

--- a/src/lib/akyo-entry.test.ts
+++ b/src/lib/akyo-entry.test.ts
@@ -53,6 +53,9 @@ const extractVRChatWorldIdFromUrl =
   akyoEntryModule.extractVRChatWorldIdFromUrl as
     | ((url: string | undefined) => string | null)
     | undefined;
+const shouldResetWorldMetadata = akyoEntryModule.shouldResetWorldMetadata as
+  | ((previousUrl: string, nextUrl: string) => boolean)
+  | undefined;
 const resolveDisplaySerialForEntryUpdate =
   akyoEntryModule.resolveDisplaySerialForEntryUpdate as
     | ((args: {
@@ -222,6 +225,32 @@ test("ensureWorldCategory prepends the world marker exactly once", () => {
   assert.deepEqual(
     ensureWorldCategory?.(["ワールド", "ワールド/ペデスタル", "ワールド"]),
     ["ワールド", "ワールド/ペデスタル"],
+  );
+});
+
+test("shouldResetWorldMetadata only resets when the target world URL actually changes", () => {
+  assert.equal(typeof shouldResetWorldMetadata, "function");
+
+  assert.equal(
+    shouldResetWorldMetadata?.(
+      "https://vrchat.com/home/world/wrld_original",
+      "https://vrchat.com/home/world/wrld_updated",
+    ),
+    true,
+  );
+  assert.equal(
+    shouldResetWorldMetadata?.(
+      "https://vrchat.com/home/world/wrld_original",
+      "https://vrchat.com/home/world/wrld_original",
+    ),
+    false,
+  );
+  assert.equal(
+    shouldResetWorldMetadata?.(
+      "https://vrchat.com/home/world/wrld_original",
+      "https://vrchat.com/home/avatar/avtr_updated",
+    ),
+    false,
   );
 });
 

--- a/src/lib/akyo-entry.ts
+++ b/src/lib/akyo-entry.ts
@@ -110,6 +110,18 @@ export function ensureWorldCategory(categories: string[]): string[] {
   return [DEFAULT_WORLD_CATEGORY, ...normalized];
 }
 
+export function shouldResetWorldMetadata(
+  previousUrl: string,
+  nextUrl: string,
+): boolean {
+  const previousType = detectVrcEntryTypeFromUrl(previousUrl);
+  const nextType = detectVrcEntryTypeFromUrl(nextUrl);
+  if (nextType !== "world") {
+    return false;
+  }
+  return previousUrl.trim() !== nextUrl.trim() || previousType !== "world";
+}
+
 export function resolveDisplaySerialForEntryUpdate(args: {
   entryType: AkyoEntryType;
   id: string;

--- a/src/lib/api-helpers.test.ts
+++ b/src/lib/api-helpers.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createTimingSafeDigest,
+  parseAkyoFormData,
+  timingSafeCompare,
+} from "./api-helpers";
+
+test("timingSafeCompare authenticates equal secrets even without Workers timingSafeEqual", () => {
+  assert.equal(timingSafeCompare("shared-secret", "shared-secret"), true);
+  assert.equal(timingSafeCompare("shared-secret", "different-secret"), false);
+});
+
+test("createTimingSafeDigest returns fixed-length digests for different input lengths", () => {
+  const shortDigest = createTimingSafeDigest("a");
+  const longDigest = createTimingSafeDigest(
+    "this-is-a-much-longer-input-than-the-short-secret",
+  );
+
+  assert.equal(shortDigest.byteLength, longDigest.byteLength);
+  assert.notDeepEqual([...shortDigest], [...longDigest]);
+});
+
+test("parseAkyoFormData rejects world submissions with a non-world source URL", () => {
+  const formData = new FormData();
+  formData.append("id", "0746");
+  formData.append("entryType", "world");
+  formData.append("nickname", "Broken World");
+  formData.append("author", "Author");
+  formData.append("sourceUrl", "https://vrchat.com/home/world/not-a-wrld-id");
+
+  assert.deepEqual(parseAkyoFormData(formData), {
+    success: false,
+    status: 400,
+    error: "entryType と sourceUrl の種別が一致していません",
+  });
+});
+
+test("parseAkyoFormData rejects avatar submissions with a non-avatar source URL", () => {
+  const formData = new FormData();
+  formData.append("id", "0746");
+  formData.append("entryType", "avatar");
+  formData.append("avatarName", "Broken Avatar");
+  formData.append("author", "Author");
+  formData.append("sourceUrl", "https://vrchat.com/home/world/wrld_abc-def");
+
+  assert.deepEqual(parseAkyoFormData(formData), {
+    success: false,
+    status: 400,
+    error: "entryType と sourceUrl の種別が一致していません",
+  });
+});

--- a/src/lib/api-helpers.ts
+++ b/src/lib/api-helpers.ts
@@ -4,9 +4,14 @@
  * Common utilities for API routes including session validation and CSRF protection.
  */
 
+import {
+  createHash,
+  timingSafeEqual as nodeTimingSafeEqual,
+} from "node:crypto";
 import { cookies } from "next/headers";
 import { connection } from "next/server";
 import type { AkyoEntryType } from "@/types/akyo";
+import { detectVrcEntryTypeFromUrl } from "./akyo-entry";
 import {
   SessionData,
   validateSession as validateSessionToken,
@@ -37,17 +42,30 @@ export function timingSafeCompare(a: string, b: string): boolean {
     const encoder = new TextEncoder();
     const bufA = encoder.encode(a);
     const bufB = encoder.encode(b);
+    const subtle = crypto.subtle as SubtleCrypto & {
+      timingSafeEqual?: (a: ArrayBufferView, b: ArrayBufferView) => boolean;
+    };
 
     // crypto.subtle.timingSafeEqual throws when lengths differ.
     // Compare user input against itself (constant-time no-op) and
     // negate so that length mismatches never leak timing information.
     const lengthsMatch = bufA.byteLength === bufB.byteLength;
-    return lengthsMatch
-      ? crypto.subtle.timingSafeEqual(bufA, bufB)
-      : !crypto.subtle.timingSafeEqual(bufA, bufA);
+    if (typeof subtle.timingSafeEqual === "function") {
+      return lengthsMatch
+        ? subtle.timingSafeEqual(bufA, bufB)
+        : !subtle.timingSafeEqual(bufA, bufA);
+    }
+
+    const digestA = createTimingSafeDigest(a);
+    const digestB = createTimingSafeDigest(b);
+    return nodeTimingSafeEqual(digestA, digestB);
   } catch {
     return false;
   }
+}
+
+export function createTimingSafeDigest(value: string): Buffer {
+  return createHash("sha256").update(value).digest();
 }
 
 /**
@@ -408,6 +426,14 @@ export function parseAkyoFormData(formData: FormData): AkyoFormParseResult {
       success: false,
       status: 400,
       error: "有効な4桁ID（0001-9999）が必要です",
+    };
+  }
+
+  if (detectVrcEntryTypeFromUrl(sourceUrl) !== entryType) {
+    return {
+      success: false,
+      status: 400,
+      error: "entryType と sourceUrl の種別が一致していません",
     };
   }
 


### PR DESCRIPTION
## Summary
- prevent favorite toggles from being lost during refetches, cross-tab sync, and transient localStorage write failures
- add regression tests for favorite persistence helpers, retry scheduling, URL validation, and timing-safe digest behavior
- harden admin-side world URL and secret validation so invalid updates fail safely in both Node and Workers paths

## Test plan
- [x] `node --test --import tsx "src/lib/world-registration.test.ts" "src/lib/akyo-entry.test.ts" "src/lib/api-helpers.test.ts" "src/hooks/use-akyo-data.test.ts"`
- [x] `ReadLints` on edited files
EOF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * お気に入り機能がタブ間で同期されるようになりました
  * ワールドURLの変更時にメタデータが自動的にリセットされるようになりました

* **セキュリティ**
  * タイミング攻撃対策が強化されました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->