### PR TITLE
Restore pink gradient for list view header

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -520,8 +520,8 @@ select:focus {
 }
 
 .list-view-table thead {
-  background: linear-gradient(135deg, #f97316 0%, #fb923c 100%);
-  color: #2d1600; /* #4a2500 → #2d1600 に変更（約5.5:1） */
+  background: linear-gradient(135deg, var(--primary-pink) 0%, var(--primary-orange) 100%);
+  color: #2d1600; /* 濃い文字色は維持してコントラストを確保 */
 }
 
 .list-view-table th {


### PR DESCRIPTION
## Summary
- restore the list view header gradient from orange-only back to the pink-to-orange theme
- keep the darker header text color introduced for accessibility contrast

## Verification
- npx playwright test tests/a11y.spec.ts --project=chromium

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Style**
  * リストビューテーブルヘッダーの背景カラースキームが更新されました。新しいカラー変数に基づいたグラデーションを採用し、視覚的な統一性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->