### PR TITLE
docs: sync README with recent mobile filter and image behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,6 +653,12 @@ These are not meant to be highly secure passwords, but rather easy-to-remember c
 
 ## ✨ Features
 
+### Recent behavior updates (2026-03)
+
+- **Mobile filter panel default**: On first render, mobile keeps the filter panel closed by default (`isMobile === true`), while desktop keeps it open.
+- **Catalog card image request width**: Card image width is tuned per entry type (`avatar: 512`, `world: 384`) to reduce world-card transfer size.
+- **Accessibility fixes (WCAG 2.1)**: Recent updates include contrast and keyboard/semantic improvements across filter controls and related UI.
+
 ### 1. Avatar Gallery
 
 - **Avatars**: Complete database with 4-digit IDs, JP/EN/KO data


### PR DESCRIPTION
## Summary\n- add a recent behavior updates section in README\n- document mobile first-render filter-panel default (closed on mobile, open on desktop)\n- document catalog card image request widths (avatar 512 / world 384)\n- note recent WCAG 2.1 UI accessibility improvements\n\n## Verification\n- checked against current implementation:\n  - src/app/zukan/filter-panel-state.ts\n  - src/app/zukan/zukan-client.tsx\n  - src/components/akyo-card.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * モバイルデバイスでフィルタパネルのデフォルト表示をクローズ状態に変更。デスクトップ版はオープン状態を維持します。
  * カタログカード画像の読み込み幅を最適化。エントリタイプごとに幅を調整（アバター: 512px、ワールド: 384px）。

* **アクセシビリティ改善**
  * WCAG 2.1対応。フィルタコントロールとUIのコントラスト、キーボード操作、セマンティック実装を改善。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->