### PR TITLE
Fix global search focus outline styling

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -223,15 +223,6 @@ a:focus-visible,
   }
 }
 
-/* 全体検索のフォーカスは作者フィルター入力と同系統に揃える */
-.search-input:focus,
-.search-input:focus-visible {
-  outline: none !important;
-  outline-offset: 0 !important;
-  border-color: rgb(43, 127, 255) !important;
-  box-shadow: 0 0 0 2px rgba(147, 197, 253, 0.5) !important;
-}
-
 /* ドロップダウン（属性・作者フィルター） */
 select {
   border-radius: 15px !important;

--- a/src/components/search-bar.tsx
+++ b/src/components/search-bar.tsx
@@ -95,7 +95,7 @@ export function SearchBar({
         value={query}
         onChange={handleChange}
         placeholder={placeholder}
-        className="search-input w-full rounded-[25px] border-[3px] border-[var(--primary-blue)] bg-white px-5 py-3 pl-[60px] text-[18px] focus:outline-none focus-visible:outline-none"
+        className="search-input w-full rounded-[25px] border-[3px] border-[var(--primary-blue)] bg-white px-5 py-3 pl-[60px] text-[18px] focus:border-[#2b7fff] focus:ring-2 focus:ring-blue-300/50 focus:outline-none focus-visible:border-[#2b7fff] focus-visible:ring-2 focus-visible:ring-blue-300/50 focus-visible:outline-none"
         aria-label={ariaLabel}
         autoComplete="off"
         spellCheck="false"

--- a/tests/filter-panel.spec.ts
+++ b/tests/filter-panel.spec.ts
@@ -73,6 +73,8 @@ test.describe("Search input focus styling", () => {
     const authorFocusStyles = await readFocusStyles(authorSearch);
     const globalFocusStyles = await readFocusStyles(globalSearch);
 
+    expect(authorFocusStyles.boxShadow).toContain("0px 0px 0px 2px");
+    expect(globalFocusStyles.boxShadow).toContain("0px 0px 0px 2px");
     expect(globalFocusStyles).toEqual(authorFocusStyles);
   });
 });


### PR DESCRIPTION
## Summary
- align the global search input focus outline with the author filter search input
- remove the inconsistent global focus outline override and keep the search bar styling local to the component
- add a Playwright regression test that compares both focused input styles

## Testing
- CI=1 npm test -- tests/filter-panel.spec.ts
- npx eslint src/components/search-bar.tsx tests/filter-panel.spec.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Style**
  * 検索入力の見た目を更新し、フォーカス時のボーダー色・影などのスタイリングを整理しました（旧来のグローバルスタイルを削除、入力のスタイルを更新）。
  * グローバル検索と作者フィルターのフォーカス表示を視覚的に一致させました。

* **Tests**
  * 検索入力のフォーカススタイリングが作者フィルターと一致することを検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->