### PR TITLE
fix: add R2 upload retry and idempotent git commit in sync workflow

### DIFF
--- a/.github/workflows/sync-json-data.yml
+++ b/.github/workflows/sync-json-data.yml
@@ -108,6 +108,13 @@ jobs:
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git add -- "$JSON_JA" "$JSON_EN" "$JSON_KO"
+
+          # Skip commit if nothing staged (idempotent for re-runs)
+          if git diff --cached --quiet; then
+            echo "ℹ️ No staged changes, skipping commit (likely a re-run)"
+            exit 0
+          fi
+
           git commit -m "chore: auto-sync JSON data from CSV changes"
 
           MAX_RETRIES=3
@@ -185,6 +192,7 @@ jobs:
 
           echo "Uploading JSON files to R2..."
           UPLOAD_FAILED=false
+          MAX_RETRIES=3
 
           for LANG in JA EN KO; do
             JSON_VAR="JSON_FILE_${LANG}"
@@ -192,10 +200,25 @@ jobs:
             JSON_PATH="data/${JSON_FILE}"
             R2_PATH="s3://${R2_BUCKET}/${R2_DATA_PATH}/${JSON_FILE}"
             echo "Uploading $JSON_PATH to $R2_PATH..."
-            if aws s3 cp "$JSON_PATH" "$R2_PATH" --endpoint-url "$R2_ENDPOINT" --content-type "application/json"; then
-              echo "✅ Uploaded ${JSON_FILE}"
-            else
-              echo "::error::Failed to upload ${JSON_FILE}"
+
+            RETRY=0
+            SUCCESS=false
+            while [ $RETRY -lt $MAX_RETRIES ]; do
+              RETRY=$((RETRY + 1))
+              if aws s3 cp "$JSON_PATH" "$R2_PATH" --endpoint-url "$R2_ENDPOINT" --content-type "application/json"; then
+                echo "✅ Uploaded ${JSON_FILE} (attempt $RETRY/$MAX_RETRIES)"
+                SUCCESS=true
+                break
+              fi
+              echo "::warning::Upload failed for ${JSON_FILE} (attempt $RETRY/$MAX_RETRIES)"
+              if [ $RETRY -lt $MAX_RETRIES ]; then
+                DELAY=$((RETRY * 5))
+                echo "Retrying in ${DELAY}s..."
+                sleep $DELAY
+              fi
+            done
+            if [ "$SUCCESS" = false ]; then
+              echo "::error::Failed to upload ${JSON_FILE} after $MAX_RETRIES attempts"
               UPLOAD_FAILED=true
             fi
           done


### PR DESCRIPTION
## Summary
- R2アップロードにリトライ機能追加（最大3回、指数バックオフ5s/10s）
- git commitステップを冪等化（再実行時にステージング済み変更がなければスキップ）

## Background
PR #354 マージ時に `Sync JSON Data from CSV` ワークフローでCloudflare R2の一時的な`InternalError`により日本語JSONアップロードが失敗。再実行時にはgit commitが既にpush済みのためrebaseコンフリクトが発生し、R2アップロードまで到達できなかった。

## Changes
- R2アップロード: 各ファイルごとに最大3回リトライ（5s, 10s遅延）
- git commit: `git diff --cached --quiet` で変更なしを検出し早期リターン

## Test plan
- [x] ワークフロー構文チェック（YAML有効性）
- [ ] 手動dispatch実行で正常動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * JSONデータの同期処理の信頼性が向上しました
  * データ同期失敗時の自動リトライ機能が追加されました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->