### PR TITLE
docs: sync README with latest Akyo data snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ npm run dev
 - ✅ **Dual Admin System** (Owner/Admin role separation)
 - ✅ **On-demand ISR** (Revalidation API + KV Edge Cache)
 
+### Data Snapshot (origin/main @ 2026-05-11)
+- `data/akyo-data-ja.json`: `count = 842`
+- `data/akyo-data-en.json`: `count = 816`
+- `data/akyo-data-ko.json`: `count = 816`
+- JSON payload format: `{ version, language, updatedAt, count, data[] }`
+
 ---
 
 ## 📖 Glossary
@@ -1333,6 +1339,6 @@ For questions or issues:
 
 ---
 
-**Last Updated**: 2026-03-07  
+**Last Updated**: 2026-05-15  
 **Status**: ✅ Production Ready
 


### PR DESCRIPTION
## Summary\n- update README data snapshot to match current data/akyo-data-*.json metadata on main\n- document current record counts (ja=842, n=816, ko=816)\n- refresh README last-updated date to 2026-05-15\n\n## Verification\n- confirmed kyobox main has no commits within last 200 hours\n- confirmed kyodex main has commits within last 200 hours and README now matches JSON schema/count metadata\n