### PR TITLE
[codex] Refresh Akyodex README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ npm run dev
 
 ### Key Features
 - 🎨 **アバター＋ワールドデータベース** - 4桁ID管理システム（日本語/英語/韓国語 CSV + JSON データ、avatar/world 二種別）
+- 📚 **収録状況** - 897 entries（avatars 808 / worlds 89）、最新ID `0897` / avatar display `0808` / world display `0089`
 - 🔐 **Admin Panel** - HMAC署名セッション認証、画像クロッピング、VRChat連携
 - 📱 **PWA対応** - 6種類のキャッシング戦略
 - 🌍 **多言語対応** - 日本語/英語/韓国語（自動検出 + 手動切替）
@@ -103,8 +104,9 @@ npm run dev
 - 🔍 **Sentry 監視** - エラー追跡 + パフォーマンスモニタリング
 
 ### Project Status
-- ✅ **Next.js 16.1.6 + Cloudflare Pages** (OpenNext adapter)
+- ✅ **Next.js 16.1.7 + Cloudflare Pages** (OpenNext adapter)
 - ✅ **Avatar + World Support** (Dual entry types with separate display IDs)
+- ✅ **Latest Data Sync** (CSV/JSON data current through Akyo #0897)
 - ✅ **Security Hardening** (Timing attack, XSS prevention, Input validation)
 - ✅ **PWA Implementation** (Service Worker with 6 caching strategies)
 - ✅ **VRChat Image Fallback** (3-tier fallback: R2 → VRChat page/API → Placeholder)
@@ -178,7 +180,7 @@ Data Source Priority: KV (~5ms) → JSON (~20ms) → CSV (~200ms)
 ## 🛠️ Tech Stack
 
 ### Frontend
-- **Framework**: Next.js 16.1.6 (App Router)
+- **Framework**: Next.js 16.1.7 (App Router)
 - **React**: 19.2.4 (Server/Client Components)
 - **Styling**: Tailwind CSS 4 (PostCSS plugin)
 - **Fonts**: Google Fonts (M PLUS Rounded 1c, Kosugi Maru, Noto Sans JP)
@@ -186,7 +188,7 @@ Data Source Priority: KV (~5ms) → JSON (~20ms) → CSV (~200ms)
 
 ### Backend
 - **Runtime**: Cloudflare Pages (Edge + Node.js Runtime)
-- **Adapter**: @opennextjs/cloudflare ^1.16.5
+- **Adapter**: @opennextjs/cloudflare ^1.17.1
 - **Authentication**: HMAC-signed sessions (Web Crypto API)
 - **Session Storage**: Cloudflare KV
 - **File Storage**: Cloudflare R2
@@ -194,7 +196,7 @@ Data Source Priority: KV (~5ms) → JSON (~20ms) → CSV (~200ms)
 - **Data Sync**: GitHub API (CSV commit on CRUD operations)
 
 ### Observability
-- **Error Tracking**: Sentry (@sentry/nextjs ^10.39.0) — runtime errors + performance monitoring
+- **Error Tracking**: Sentry (@sentry/nextjs ^10.44.0) — runtime errors + performance monitoring
 - **Instrumentation**: Server-side (`instrumentation.ts`) + client-side (`instrumentation-client.ts`)
 
 ### Security
@@ -207,11 +209,12 @@ Data Source Priority: KV (~5ms) → JSON (~20ms) → CSV (~200ms)
 
 ### DevOps
 - **Package Manager**: npm 10.x
-- **Node Version**: 20.x
+- **Node Version**: 20.9.0 or later
 - **TypeScript**: 5.9.3 (Strict mode)
 - **Linting**: ESLint 9 with Next.js config
 - **Testing**: Playwright (E2E), node:test + assert (unit tests)
 - **Dead Code Analysis**: Knip
+- **Cloudflare CLI**: Wrangler ^4.75.0
 - **Git Workflow**: Feature branches → PR → main
 - **CI/CD**: Cloudflare Pages automatic deployment
 
@@ -436,6 +439,7 @@ npm run start            # Start production server (local)
 # Quality
 npm run lint             # Run ESLint
 npm run knip             # Dead code analysis
+npm run verify:dify-csp-hash  # Verify the Dify embed CSP hash
 
 # Testing
 npm run test             # Run Playwright E2E tests
@@ -446,6 +450,11 @@ npm run test:csv         # CSV data quality checks
 
 # Data
 npm run data:convert     # Convert CSV to JSON (npx tsx scripts/csv-to-json.ts)
+npm run generate-ko-data # Generate Korean data from Japanese source
+
+# Social images
+npm run social:generate  # Generate social preview images
+npm run social:compress  # Compress generated social preview images
 ```
 
 ---
@@ -659,9 +668,17 @@ These are not meant to be highly secure passwords, but rather easy-to-remember c
 - **Catalog card image request width**: Card image width is tuned per entry type (`avatar: 512`, `world: 384`) to reduce world-card transfer size.
 - **Accessibility fixes (WCAG 2.1)**: Recent updates include contrast and keyboard/semantic improvements across filter controls and related UI.
 
+### Data freshness (2026-07)
+
+- **Current Japanese source data**: `data/akyo-data-ja.csv` / `.json` contain 897 entries: 808 avatars and 89 worlds.
+- **Latest repository ID**: `0897` (`サスペンダーきつねAkyo` / `akyo_きつねサスペンダー`).
+- **Display serials**: latest avatar display serial is `0808`; latest world display serial is `0089`.
+- **Automated sync**: pushes to `main` that touch JA/EN/KO CSV files run `sync-json-data.yml`, regenerate JSON, upload JSON to R2, and trigger `/api/revalidate` when `REVALIDATE_SECRET` is configured.
+
 ### 1. Avatar Gallery
 
-- **Avatars**: Complete database with 4-digit IDs, JP/EN/KO data
+- **Avatars**: 808 avatar entries with 4-digit IDs, JP/EN/KO data
+- **Worlds**: 89 world entries sharing the same data pipeline and gallery UI
 - **Search**: By nickname, avatar name, category, author
 - **Filtering**: Multi-select categories (OR/AND) + multi-select authors
 - **Keyboard A11y**: Arrow/Home/End/Enter support in filter lists
@@ -1240,7 +1257,7 @@ export const runtime = 'nodejs';
 - ✅ Nonce-based CSP via middleware
 
 ### Phase 10: Next.js 16 + World Support (Completed)
-- ✅ Next.js 15 → 16 upgrade (React 19.2.4, @opennextjs/cloudflare ^1.16.5)
+- ✅ Next.js 15 → 16 upgrade (React 19.2.4, @opennextjs/cloudflare ^1.17.1)
 - ✅ World entry type support (avatar + world dual entries)
 - ✅ Entry normalization (`hydrateAkyoDataset` — type inference, display serial allocation)
 - ✅ VRChat World APIs (`vrc-world-info`, `vrc-world-image`)
@@ -1248,6 +1265,11 @@ export const runtime = 'nodejs';
 - ✅ Korean language data support (`akyo-data-ko.csv`)
 - ✅ Sentry integration (error tracking + performance monitoring)
 - ✅ Korean data generation script (`generate-ko-data.js`)
+
+### Phase 11: Data Operations Refresh (Completed 2026-07)
+- ✅ CSV/JSON data refreshed through repository ID `0897`
+- ✅ Current dataset documents 808 avatar entries and 89 world entries
+- ✅ Sync workflow regenerates JA/EN/KO JSON, uploads to R2, and refreshes ISR/KV cache when secrets are configured
 
 ---
 
@@ -1333,6 +1355,6 @@ For questions or issues:
 
 ---
 
-**Last Updated**: 2026-03-07  
+**Last Updated**: 2026-07-01  
 **Status**: ✅ Production Ready
 


### PR DESCRIPTION
## Summary
- Update README dependency/status details to match package.json and current Cloudflare/OpenNext setup.
- Document current dataset freshness through repository ID 0897, including avatar/world counts and display serials.
- Add missing package scripts for Dify CSP verification, Korean data generation, and social image generation/compression.

## Validation
- Checked origin/main commits within the last 200 hours for akyobox and akyodex.
- Confirmed akyobox has no origin/main commits in that window; latest origin/main commit is 2026-03-04.
- Confirmed Akyodex data from data/akyo-data-ja.json: 897 total entries, 808 avatars, 89 worlds, latest ID 0897.
- Ran a Node consistency check to ensure README contains current package/data values.
- No build run; README-only documentation change.