### PR TITLE
Require the Worker ingest secret

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,8 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+.dev.vars
+.dev.vars.*
 
 # vercel
 .vercel

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:playwright": "playwright test",
     "test:ui": "playwright test --ui",
     "test:headed": "playwright test --headed",
-    "test:worker": "tsx --test workers/akyo-search-worker/src/*.test.ts",
+    "test:worker": "tsx --test workers/akyo-search-worker/src/*.test.ts scripts/upload-vectorize-data.test.js",
     "typecheck:worker": "tsc -p workers/akyo-search-worker/tsconfig.json",
     "build:worker": "wrangler deploy --dry-run --config workers/akyo-search-worker/wrangler.jsonc",
     "test:csv": "node scripts/test-csv-quality.js",

--- a/scripts/upload-vectorize-data.js
+++ b/scripts/upload-vectorize-data.js
@@ -20,14 +20,18 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function parseArgs() {
-  const args = process.argv.slice(2);
+function parseArgs(args = process.argv.slice(2)) {
   let batchSize = DEFAULT_BATCH_SIZE;
   let dryRun = false;
 
   for (let i = 0; i < args.length; i++) {
-    if (args[i] === '--batch-size' && args[i + 1]) {
-      batchSize = parseInt(args[i + 1], 10);
+    if (args[i] === '--batch-size') {
+      const value = args[i + 1];
+      const parsed = Number(value);
+      if (!value || !Number.isInteger(parsed) || parsed <= 0) {
+        throw new Error('--batch-size must be a positive integer');
+      }
+      batchSize = parsed;
       i++;
     }
     if (args[i] === '--dry-run') {
@@ -157,5 +161,6 @@ module.exports = {
   buildRequestHeaders,
   getIngestToken,
   getWorkerUrl,
+  parseArgs,
   sendBatch,
 };

--- a/scripts/upload-vectorize-data.js
+++ b/scripts/upload-vectorize-data.js
@@ -13,8 +13,10 @@ const DEFAULT_WORKER_URL =
 const INGEST_TOKEN_ENV = 'AKYO_INGEST_TOKEN';
 const WORKER_URL_ENV = 'AKYO_WORKER_URL';
 const DEFAULT_BATCH_SIZE = 50;
+const MAX_BATCH_SIZE = 1000;
 const RETRY_LIMIT = 3;
 const RETRY_DELAY_MS = 3000;
+const REQUEST_TIMEOUT_MS = 30_000;
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -28,8 +30,15 @@ function parseArgs(args = process.argv.slice(2)) {
     if (args[i] === '--batch-size') {
       const value = args[i + 1];
       const parsed = Number(value);
-      if (!value || !Number.isInteger(parsed) || parsed <= 0) {
-        throw new Error('--batch-size must be a positive integer');
+      if (
+        !value ||
+        !Number.isSafeInteger(parsed) ||
+        parsed < 1 ||
+        parsed > MAX_BATCH_SIZE
+      ) {
+        throw new Error(
+          `--batch-size must be an integer from 1 through ${MAX_BATCH_SIZE}`
+        );
       }
       batchSize = parsed;
       i++;
@@ -64,38 +73,105 @@ function buildRequestHeaders(ingestToken) {
   };
 }
 
-async function sendBatch(
-  records,
-  batchIndex,
-  { workerUrl, ingestToken },
-  retries = 0
-) {
-  const res = await fetch(workerUrl, {
-    method: 'POST',
-    headers: buildRequestHeaders(ingestToken),
-    body: JSON.stringify({ records }),
-  });
+function validateRecordsPayload(value) {
+  if (!Array.isArray(value)) {
+    throw new Error('vectorize-payload.json must contain a records array');
+  }
+  return value;
+}
 
-  if (!res.ok) {
-    const text = await res.text();
-    if (retries < RETRY_LIMIT) {
-      console.warn(
-        `  ⚠ Batch ${batchIndex} failed (${res.status}), retrying in ${RETRY_DELAY_MS / 1000}s... (${retries + 1}/${RETRY_LIMIT})`
-      );
-      await sleep(RETRY_DELAY_MS);
-      return sendBatch(
-        records,
-        batchIndex,
-        { workerUrl, ingestToken },
-        retries + 1
-      );
-    }
+function isRetryableStatus(status) {
+  return status === 408 || status === 429 || status >= 500;
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function responseSummary(text) {
+  return text.length > 1000 ? `${text.slice(0, 1000)}...` : text;
+}
+
+async function retryBatch(records, batchIndex, options, retries, reason) {
+  if (retries >= RETRY_LIMIT) {
     throw new Error(
-      `Batch ${batchIndex} failed after ${RETRY_LIMIT} retries: ${res.status} ${text}`
+      `Batch ${batchIndex} failed after ${RETRY_LIMIT} retries: ${reason}`
     );
   }
 
-  return res.json();
+  const delayMs = options.retryDelayMs ?? RETRY_DELAY_MS;
+  console.warn(
+    `  ⚠ Batch ${batchIndex} failed (${reason}), retrying in ${delayMs / 1000}s... (${retries + 1}/${RETRY_LIMIT})`
+  );
+  await sleep(delayMs);
+  return sendBatch(records, batchIndex, options, retries + 1);
+}
+
+async function sendBatch(records, batchIndex, options, retries = 0) {
+  const { workerUrl, ingestToken } = options;
+  let res;
+  try {
+    res = await fetch(workerUrl, {
+      method: 'POST',
+      headers: buildRequestHeaders(ingestToken),
+      body: JSON.stringify({ records }),
+      signal: AbortSignal.timeout(
+        options.requestTimeoutMs ?? REQUEST_TIMEOUT_MS
+      ),
+    });
+  } catch (error) {
+    return retryBatch(
+      records,
+      batchIndex,
+      options,
+      retries,
+      `network error: ${errorMessage(error)}`
+    );
+  }
+
+  const text = await res.text();
+  if (!res.ok) {
+    const reason = `HTTP ${res.status}: ${responseSummary(text)}`;
+    if (isRetryableStatus(res.status)) {
+      return retryBatch(records, batchIndex, options, retries, reason);
+    }
+    throw new Error(`Batch ${batchIndex} failed without retry: ${reason}`);
+  }
+
+  let result;
+  try {
+    result = JSON.parse(text);
+  } catch {
+    return retryBatch(
+      records,
+      batchIndex,
+      options,
+      retries,
+      'success response was not valid JSON'
+    );
+  }
+
+  if (result === null || typeof result !== 'object' || Array.isArray(result)) {
+    return retryBatch(
+      records,
+      batchIndex,
+      options,
+      retries,
+      'success response was not a JSON object'
+    );
+  }
+
+  if (result?.ok === false || Number(result?.failed) > 0) {
+    return retryBatch(
+      records,
+      batchIndex,
+      options,
+      retries,
+      `application failure: ${responseSummary(text)}`
+    );
+  }
+
+  return result;
 }
 
 async function main() {
@@ -109,7 +185,9 @@ async function main() {
     process.exit(1);
   }
 
-  const records = JSON.parse(fs.readFileSync(payloadPath, 'utf8'));
+  const records = validateRecordsPayload(
+    JSON.parse(fs.readFileSync(payloadPath, 'utf8'))
+  );
   const totalBatches = Math.ceil(records.length / batchSize);
 
   console.log(`Records: ${records.length}`);
@@ -161,6 +239,8 @@ module.exports = {
   buildRequestHeaders,
   getIngestToken,
   getWorkerUrl,
+  isRetryableStatus,
   parseArgs,
   sendBatch,
+  validateRecordsPayload,
 };

--- a/scripts/upload-vectorize-data.js
+++ b/scripts/upload-vectorize-data.js
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+/**
+ * Upload vectorize payload to akyo-search-worker in batches.
+ *
+ * Usage: node scripts/upload-vectorize-data.js [--batch-size 50] [--dry-run]
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const DEFAULT_WORKER_URL =
+  'https://akyo-search-worker.dorado1031.workers.dev/insert-data';
+const INGEST_TOKEN_ENV = 'AKYO_INGEST_TOKEN';
+const WORKER_URL_ENV = 'AKYO_WORKER_URL';
+const DEFAULT_BATCH_SIZE = 50;
+const RETRY_LIMIT = 3;
+const RETRY_DELAY_MS = 3000;
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  let batchSize = DEFAULT_BATCH_SIZE;
+  let dryRun = false;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--batch-size' && args[i + 1]) {
+      batchSize = parseInt(args[i + 1], 10);
+      i++;
+    }
+    if (args[i] === '--dry-run') {
+      dryRun = true;
+    }
+  }
+
+  return { batchSize, dryRun };
+}
+
+function getIngestToken(environment = process.env) {
+  const token = environment[INGEST_TOKEN_ENV]?.trim();
+  if (!token) {
+    throw new Error(`${INGEST_TOKEN_ENV} is not configured`);
+  }
+  return token;
+}
+
+function getWorkerUrl(environment = process.env) {
+  return environment[WORKER_URL_ENV]?.trim() || DEFAULT_WORKER_URL;
+}
+
+function buildRequestHeaders(ingestToken) {
+  if (!ingestToken) {
+    throw new Error('ingest token is required');
+  }
+  return {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${ingestToken}`,
+  };
+}
+
+async function sendBatch(
+  records,
+  batchIndex,
+  { workerUrl, ingestToken },
+  retries = 0
+) {
+  const res = await fetch(workerUrl, {
+    method: 'POST',
+    headers: buildRequestHeaders(ingestToken),
+    body: JSON.stringify({ records }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    if (retries < RETRY_LIMIT) {
+      console.warn(
+        `  ⚠ Batch ${batchIndex} failed (${res.status}), retrying in ${RETRY_DELAY_MS / 1000}s... (${retries + 1}/${RETRY_LIMIT})`
+      );
+      await sleep(RETRY_DELAY_MS);
+      return sendBatch(
+        records,
+        batchIndex,
+        { workerUrl, ingestToken },
+        retries + 1
+      );
+    }
+    throw new Error(
+      `Batch ${batchIndex} failed after ${RETRY_LIMIT} retries: ${res.status} ${text}`
+    );
+  }
+
+  return res.json();
+}
+
+async function main() {
+  const { batchSize, dryRun } = parseArgs();
+  const workerUrl = getWorkerUrl();
+  const payloadPath = path.resolve(__dirname, '..', 'data', 'vectorize-payload.json');
+
+  if (!fs.existsSync(payloadPath)) {
+    console.error(`ペイロードファイルがありません: ${payloadPath}`);
+    console.error('先に node scripts/generate-vectorize-payload.js を実行してください');
+    process.exit(1);
+  }
+
+  const records = JSON.parse(fs.readFileSync(payloadPath, 'utf8'));
+  const totalBatches = Math.ceil(records.length / batchSize);
+
+  console.log(`Records: ${records.length}`);
+  console.log(`Batch size: ${batchSize}`);
+  console.log(`Total batches: ${totalBatches}`);
+  console.log(`Endpoint: ${workerUrl}`);
+  if (dryRun) {
+    console.log('\n--dry-run: 実際には送信しません');
+    return;
+  }
+  const ingestToken = getIngestToken();
+  console.log('');
+
+  let totalProcessed = 0;
+
+  for (let i = 0; i < totalBatches; i++) {
+    const start = i * batchSize;
+    const batch = records.slice(start, start + batchSize);
+    const idRange = `${batch[0].id}–${batch[batch.length - 1].id}`;
+
+    process.stdout.write(
+      `  [${i + 1}/${totalBatches}] ${idRange} (${batch.length} records)...`
+    );
+
+    const result = await sendBatch(batch, i + 1, {
+      workerUrl,
+      ingestToken,
+    });
+    totalProcessed += result.processed || 0;
+    console.log(` ✓ processed: ${result.processed}`);
+
+    // Small delay between batches to avoid rate limits
+    if (i < totalBatches - 1) {
+      await sleep(1000);
+    }
+  }
+
+  console.log(`\n✅ Done! Total processed: ${totalProcessed}/${records.length}`);
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error('\n❌ Error:', err.message);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  buildRequestHeaders,
+  getIngestToken,
+  getWorkerUrl,
+  sendBatch,
+};

--- a/scripts/upload-vectorize-data.test.js
+++ b/scripts/upload-vectorize-data.test.js
@@ -1,0 +1,67 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+  buildRequestHeaders,
+  getIngestToken,
+  getWorkerUrl,
+  sendBatch,
+} = require('./upload-vectorize-data');
+
+test('requires the ingest token outside dry-run orchestration', () => {
+  assert.throws(
+    () => getIngestToken({}),
+    /AKYO_INGEST_TOKEN is not configured/
+  );
+  assert.equal(getIngestToken({ AKYO_INGEST_TOKEN: '  secret-value  ' }), 'secret-value');
+});
+
+test('uses the production endpoint by default and accepts a preview override', () => {
+  assert.equal(
+    getWorkerUrl({}),
+    'https://akyo-search-worker.dorado1031.workers.dev/insert-data'
+  );
+  assert.equal(
+    getWorkerUrl({ AKYO_WORKER_URL: ' https://preview.example/insert-data ' }),
+    'https://preview.example/insert-data'
+  );
+});
+
+test('builds an authenticated JSON request', () => {
+  assert.deepEqual(buildRequestHeaders('secret-value'), {
+    'Content-Type': 'application/json',
+    Authorization: 'Bearer secret-value',
+  });
+  assert.throws(() => buildRequestHeaders(''), /ingest token is required/);
+});
+
+test('sends records with the configured bearer token', async () => {
+  const originalFetch = global.fetch;
+  let capturedRequest;
+  global.fetch = async (url, options) => {
+    capturedRequest = { url, options };
+    return {
+      ok: true,
+      async json() {
+        return { processed: 0, indexed: 0, failed: 0, errors: [] };
+      },
+    };
+  };
+
+  try {
+    await sendBatch([], 1, {
+      workerUrl: 'https://preview.example/insert-data',
+      ingestToken: 'secret-value',
+    });
+  } finally {
+    global.fetch = originalFetch;
+  }
+
+  assert.equal(capturedRequest.url, 'https://preview.example/insert-data');
+  assert.equal(capturedRequest.options.method, 'POST');
+  assert.equal(
+    capturedRequest.options.headers.Authorization,
+    'Bearer secret-value'
+  );
+  assert.equal(capturedRequest.options.body, '{"records":[]}');
+});

--- a/scripts/upload-vectorize-data.test.js
+++ b/scripts/upload-vectorize-data.test.js
@@ -5,26 +5,58 @@ const {
   buildRequestHeaders,
   getIngestToken,
   getWorkerUrl,
+  isRetryableStatus,
   parseArgs,
   sendBatch,
+  validateRecordsPayload,
 } = require('./upload-vectorize-data');
 
-test('accepts only a positive integer batch size', () => {
+function fakeResponse(status, body) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    async text() {
+      return JSON.stringify(body);
+    },
+  };
+}
+
+test('accepts only a batch size from 1 through 1000', () => {
   assert.deepEqual(parseArgs(['--batch-size', '25', '--dry-run']), {
     batchSize: 25,
     dryRun: true,
   });
+  assert.equal(parseArgs(['--batch-size', '1000']).batchSize, 1000);
 
-  for (const value of ['0', '-1', '1.5', 'not-a-number']) {
+  for (const value of ['0', '-1', '1.5', '1001', '50x', 'not-a-number']) {
     assert.throws(
       () => parseArgs(['--batch-size', value]),
-      /--batch-size must be a positive integer/
+      /--batch-size must be an integer from 1 through 1000/
     );
   }
   assert.throws(
     () => parseArgs(['--batch-size']),
-    /--batch-size must be a positive integer/
+    /--batch-size must be an integer from 1 through 1000/
   );
+});
+
+test('requires the vector payload to be an array', () => {
+  const records = [{ id: '0001' }];
+  assert.equal(validateRecordsPayload(records), records);
+  assert.throws(
+    () => validateRecordsPayload({ records }),
+    /vectorize-payload.json must contain a records array/
+  );
+});
+
+test('retries only transient HTTP statuses', () => {
+  assert.equal(isRetryableStatus(408), true);
+  assert.equal(isRetryableStatus(429), true);
+  assert.equal(isRetryableStatus(500), true);
+  assert.equal(isRetryableStatus(503), true);
+  assert.equal(isRetryableStatus(400), false);
+  assert.equal(isRetryableStatus(401), false);
+  assert.equal(isRetryableStatus(413), false);
 });
 
 test('requires the ingest token outside dry-run orchestration', () => {
@@ -59,12 +91,13 @@ test('sends records with the configured bearer token', async () => {
   let capturedRequest;
   global.fetch = async (url, options) => {
     capturedRequest = { url, options };
-    return {
+    return fakeResponse(200, {
       ok: true,
-      async json() {
-        return { processed: 0, indexed: 0, failed: 0, errors: [] };
-      },
-    };
+      processed: 0,
+      indexed: 0,
+      failed: 0,
+      errors: [],
+    });
   };
 
   try {
@@ -83,4 +116,128 @@ test('sends records with the configured bearer token', async () => {
     'Bearer secret-value'
   );
   assert.equal(capturedRequest.options.body, '{"records":[]}');
+  assert.ok(capturedRequest.options.signal instanceof AbortSignal);
+});
+
+test('does not retry permanent HTTP errors', async () => {
+  const originalFetch = global.fetch;
+  let fetchCalls = 0;
+  global.fetch = async () => {
+    fetchCalls += 1;
+    return fakeResponse(401, { error: 'Unauthorized' });
+  };
+
+  try {
+    await assert.rejects(
+      sendBatch([], 1, {
+        workerUrl: 'https://preview.example/insert-data',
+        ingestToken: 'wrong-value',
+        retryDelayMs: 0,
+      }),
+      /failed without retry: HTTP 401/
+    );
+  } finally {
+    global.fetch = originalFetch;
+  }
+
+  assert.equal(fetchCalls, 1);
+});
+
+test('retries a transient response and then succeeds', async () => {
+  const originalFetch = global.fetch;
+  const originalWarn = console.warn;
+  let fetchCalls = 0;
+  console.warn = () => undefined;
+  global.fetch = async () => {
+    fetchCalls += 1;
+    if (fetchCalls === 1) {
+      return fakeResponse(503, { error: 'Unavailable' });
+    }
+    return fakeResponse(200, {
+      ok: true,
+      processed: 0,
+      indexed: 0,
+      failed: 0,
+      errors: [],
+    });
+  };
+
+  try {
+    await sendBatch([], 1, {
+      workerUrl: 'https://preview.example/insert-data',
+      ingestToken: 'secret-value',
+      retryDelayMs: 0,
+    });
+  } finally {
+    global.fetch = originalFetch;
+    console.warn = originalWarn;
+  }
+
+  assert.equal(fetchCalls, 2);
+});
+
+test('retries a network failure and then succeeds', async () => {
+  const originalFetch = global.fetch;
+  const originalWarn = console.warn;
+  let fetchCalls = 0;
+  console.warn = () => undefined;
+  global.fetch = async () => {
+    fetchCalls += 1;
+    if (fetchCalls === 1) {
+      throw new Error('connection reset');
+    }
+    return fakeResponse(200, {
+      ok: true,
+      processed: 0,
+      indexed: 0,
+      failed: 0,
+      errors: [],
+    });
+  };
+
+  try {
+    await sendBatch([], 1, {
+      workerUrl: 'https://preview.example/insert-data',
+      ingestToken: 'secret-value',
+      retryDelayMs: 0,
+    });
+  } finally {
+    global.fetch = originalFetch;
+    console.warn = originalWarn;
+  }
+
+  assert.equal(fetchCalls, 2);
+});
+
+test('treats a 200 partial-failure response as a failed batch', async () => {
+  const originalFetch = global.fetch;
+  const originalWarn = console.warn;
+  let fetchCalls = 0;
+  console.warn = () => undefined;
+  global.fetch = async () => {
+    fetchCalls += 1;
+    return fakeResponse(200, {
+      ok: false,
+      processed: 1,
+      indexed: 0,
+      failed: 1,
+      errors: [{ id: '0001', error: 'Vectorize unavailable' }],
+    });
+  };
+
+  try {
+    await assert.rejects(
+      sendBatch([{ id: '0001' }], 1, {
+        workerUrl: 'https://preview.example/insert-data',
+        ingestToken: 'secret-value',
+        retryDelayMs: 0,
+      }),
+      /failed after 3 retries: application failure/
+    );
+  } finally {
+    global.fetch = originalFetch;
+    console.warn = originalWarn;
+  }
+
+  assert.equal(fetchCalls, 4);
 });

--- a/scripts/upload-vectorize-data.test.js
+++ b/scripts/upload-vectorize-data.test.js
@@ -5,8 +5,27 @@ const {
   buildRequestHeaders,
   getIngestToken,
   getWorkerUrl,
+  parseArgs,
   sendBatch,
 } = require('./upload-vectorize-data');
+
+test('accepts only a positive integer batch size', () => {
+  assert.deepEqual(parseArgs(['--batch-size', '25', '--dry-run']), {
+    batchSize: 25,
+    dryRun: true,
+  });
+
+  for (const value of ['0', '-1', '1.5', 'not-a-number']) {
+    assert.throws(
+      () => parseArgs(['--batch-size', value]),
+      /--batch-size must be a positive integer/
+    );
+  }
+  assert.throws(
+    () => parseArgs(['--batch-size']),
+    /--batch-size must be a positive integer/
+  );
+});
 
 test('requires the ingest token outside dry-run orchestration', () => {
   assert.throws(

--- a/workers/akyo-search-worker/README.md
+++ b/workers/akyo-search-worker/README.md
@@ -21,8 +21,27 @@ Set the ingest secret before the first deployment:
 npx wrangler secret put INGEST_TOKEN --config workers/akyo-search-worker/wrangler.jsonc
 ```
 
+`wrangler secret put` creates and deploys a new Worker version. Run it only as
+part of the approved production rollout, after the source change has merged.
+Use `wrangler versions secret put` instead when preparing a version without
+immediately routing production traffic to it.
+
 Send the same value as `Authorization: Bearer <token>` when uploading data.
 Do not put the token in the repository or in a command committed to shell history.
+The Wrangler configuration declares `INGEST_TOKEN` as required, so deployment
+validation fails when the Worker secret is missing.
+
+The upload helper reads the same value from `AKYO_INGEST_TOKEN`. Set
+`AKYO_WORKER_URL` to exercise a preview Worker before using the production URL:
+
+```powershell
+$env:AKYO_INGEST_TOKEN = "<INGEST_TOKEN>"
+$env:AKYO_WORKER_URL = "https://<preview-worker>/insert-data"
+node scripts/upload-vectorize-data.js --batch-size 50
+```
+
+Neither environment variable should be committed. `--dry-run` does not require
+the token because it does not send an HTTP request.
 
 ## Verification
 

--- a/workers/akyo-search-worker/wrangler.jsonc
+++ b/workers/akyo-search-worker/wrangler.jsonc
@@ -8,6 +8,9 @@
   "observability": {
     "enabled": true
   },
+  "secrets": {
+    "required": ["INGEST_TOKEN"]
+  },
   "ai": {
     "binding": "AI"
   },


### PR DESCRIPTION
## Summary
- declare INGEST_TOKEN as a required Worker secret
- add an authenticated Vectorize upload helper using AKYO_INGEST_TOKEN
- allow AKYO_WORKER_URL to target a preview Worker before production
- ignore local .dev.vars files and document rollout behavior

## Validation
- npm run test:worker (19 passed)
- npm run typecheck:worker
- npx tsc --noEmit
- npm run build:worker
- npx eslint --no-ignore scripts/upload-vectorize-data.js scripts/upload-vectorize-data.test.js
- node scripts/upload-vectorize-data.js --dry-run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * ベクトルデータのアップロード機能を追加。バッチ処理、再試行、ドライランモードに対応しています。

* **Tests**
  * アップロード機能のテストを追加しました。

* **Documentation**
  * ワーカー設定とアップロード手順のドキュメントを更新しました。

* **Chores**
  * 環境変数ファイルをGit追跡対象外に設定しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->