### PR TITLE
Avoid generic Akyo exact-match short circuits

### DIFF
--- a/workers/akyo-search-worker/src/search.test.ts
+++ b/workers/akyo-search-worker/src/search.test.ts
@@ -257,6 +257,34 @@ test("returns an exact D1 match without invoking Workers AI", async () => {
   assert.ok(database.exactCandidates.includes("たなばたAkyo"));
 });
 
+test("does not let a generic Akyo exact match hide a specific keyword", async () => {
+  const database = new FakeDatabase();
+  database.exactRows = [
+    row({
+      id: "0017",
+      nickname: "N/A",
+      name: "Akyo",
+      match_score: 0.98,
+      matched_field: "name",
+    }),
+  ];
+  database.partialRows = [
+    row({ match_score: 0.85, matched_field: "nickname" }),
+  ];
+
+  const results = await searchWithD1AndVectorize(
+    ["たなばた", "Akyo", "キャラクター"],
+    "ja",
+    5,
+    fakeEnv({ database })
+  );
+
+  assert.equal(results[0].id, "0893");
+  assert.equal(results[0].nickname, "たなばたAkyo");
+  assert.equal(results[0].matchType, "partial");
+  assert.ok(!database.exactCandidates.includes("Akyo"));
+});
+
 test("finds a numeric avatar ID across languages", async () => {
   const database = new FakeDatabase();
   database.exactRows = [row({ id: "0504", language: "ja" })];

--- a/workers/akyo-search-worker/src/search.test.ts
+++ b/workers/akyo-search-worker/src/search.test.ts
@@ -273,7 +273,7 @@ test("does not let a generic Akyo exact match hide a specific keyword", async ()
   ];
 
   const results = await searchWithD1AndVectorize(
-    ["たなばた", "Akyo", "キャラクター"],
+    ["たなばた", "akyo", "AKYO"],
     "ja",
     5,
     fakeEnv({ database })
@@ -282,7 +282,37 @@ test("does not let a generic Akyo exact match hide a specific keyword", async ()
   assert.equal(results[0].id, "0893");
   assert.equal(results[0].nickname, "たなばたAkyo");
   assert.equal(results[0].matchType, "partial");
-  assert.ok(!database.exactCandidates.includes("Akyo"));
+  assert.ok(
+    database.exactCandidates.every(
+      (candidate) => candidate.toLowerCase() !== "akyo"
+    )
+  );
+});
+
+test("keeps a generic Akyo exact match for a single keyword", async () => {
+  const database = new FakeDatabase();
+  database.exactRows = [
+    row({
+      id: "0017",
+      nickname: "N/A",
+      name: "Akyo",
+      match_score: 0.98,
+      matched_field: "name",
+    }),
+  ];
+  const ai = new FakeAi();
+
+  const results = await searchWithD1AndVectorize(
+    ["Akyo"],
+    "ja",
+    5,
+    fakeEnv({ database, ai })
+  );
+
+  assert.equal(results[0].id, "0017");
+  assert.equal(results[0].matchType, "exact");
+  assert.ok(database.exactCandidates.includes("Akyo"));
+  assert.deepEqual(ai.calls, []);
 });
 
 test("finds a numeric avatar ID across languages", async () => {

--- a/workers/akyo-search-worker/src/search.ts
+++ b/workers/akyo-search-worker/src/search.ts
@@ -397,9 +397,12 @@ export async function searchWithD1AndVectorize(
   const limit = normalizeTopK(requestedTopK);
   const terms = normalizeSearchTerms(undefined, rawTerms);
   const exactResults = new Map<string, SearchResult>();
+  const exactTerms = terms.length > 1
+    ? terms.filter((term) => term.toLowerCase() !== "akyo")
+    : terms;
 
   const exactMatches = await Promise.all(
-    terms.flatMap((term) =>
+    exactTerms.flatMap((term) =>
       exactCandidates(term).map((candidate) =>
         findExactCandidateMatches(candidate, language, limit, env)
       )


### PR DESCRIPTION
## Summary
- prevent the generic keyword `Akyo` from short-circuiting multi-keyword searches with unrelated exact-name matches
- keep exact matching unchanged when `Akyo` is the only search term
- add a regression test for Dify's `たなばた`, `Akyo`, `キャラクター` keyword output

## Root cause
Dify sends extracted keywords rather than the original question. For `たなばたAkyo`, the keyword `Akyo` exactly matched several generic avatar names, so the Worker returned those rows before partial and semantic search could find `たなばたAkyo`.

## Validation
- reproduced the failure first: expected `0893`, received `0017`
- `npm run test:worker` (27 tests passed)
- `npm run typecheck:worker`
- `npm run build:worker`
- targeted ESLint
- `git diff --check`

## Rollout
Deploy the Worker only after this PR merges. The current production Worker and Dify workflow remain available while this change is reviewed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 複数の検索語を指定した際、一般的な「Akyo」の完全一致結果が、より具体的なキーワードによる部分一致結果を隠さないよう検索結果を改善しました。
  * 「たなばたAkyo」など、具体的な部分一致候補が適切に表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->