### PR TITLE
Prioritize specific Worker search terms

### DIFF
--- a/workers/akyo-search-worker/src/search.test.ts
+++ b/workers/akyo-search-worker/src/search.test.ts
@@ -289,6 +289,24 @@ test("does not let a generic Akyo exact match hide a specific keyword", async ()
   );
 });
 
+test("uses only specific terms for fallback search", async () => {
+  const database = new FakeDatabase();
+  database.partialRows = [
+    row({ match_score: 0.85, matched_field: "nickname" }),
+  ];
+  const ai = new FakeAi();
+
+  const results = await searchWithD1AndVectorize(
+    ["たなばた", "Akyo", "キャラクター"],
+    "ja",
+    5,
+    fakeEnv({ database, ai })
+  );
+
+  assert.equal(results[0].id, "0893");
+  assert.deepEqual(ai.calls, ["たなばた"]);
+});
+
 test("keeps a generic Akyo exact match for a single keyword", async () => {
   const database = new FakeDatabase();
   database.exactRows = [

--- a/workers/akyo-search-worker/src/search.test.ts
+++ b/workers/akyo-search-worker/src/search.test.ts
@@ -239,6 +239,18 @@ test("limits and deduplicates generated keyword input", () => {
   assert.deepEqual(normalizeSearchTerms("たなばたAkyo", []), ["たなばたAkyo"]);
 });
 
+test("bounds the number of keyword candidates that are normalized", () => {
+  const candidateLimit = 24;
+  const keywords = Array.from({ length: candidateLimit + 1 }, () => "Akyo");
+  Object.defineProperty(keywords, candidateLimit, {
+    get() {
+      throw new Error("normalized too many keyword candidates");
+    },
+  });
+
+  assert.deepEqual(normalizeSearchTerms(undefined, keywords), ["Akyo"]);
+});
+
 test("extracts exact avatar candidates from natural-language questions", () => {
   assert.deepEqual(exactCandidates("たなばたAkyoについて教えて"), [
     "たなばたAkyo",

--- a/workers/akyo-search-worker/src/search.test.ts
+++ b/workers/akyo-search-worker/src/search.test.ts
@@ -63,6 +63,7 @@ class FakeDatabase implements D1Database {
   exactRows: FakeSearchRow[] = [];
   partialRows: FakeSearchRow[] = [];
   exactCandidates: string[] = [];
+  partialKeywords: string[] = [];
   batchFailure?: Error;
   batchCalls = 0;
   runCalls = 0;
@@ -98,6 +99,7 @@ class FakeDatabase implements D1Database {
       );
     }
     if (query.includes("WHEN category = ?")) {
+      this.partialKeywords.push(String(values[0] ?? ""));
       return this.partialRows;
     }
     return [];
@@ -223,8 +225,17 @@ test("limits and deduplicates generated keyword input", () => {
     "キャラクター",
     "アニメ",
   ]);
-  assert.deepEqual(terms, ["たなばた", "Akyo", "キャラクター"]);
-  assert.equal(terms.length, MAX_KEYWORDS);
+  assert.deepEqual(terms, ["たなばた", "アニメ"]);
+  assert.ok(terms.length <= MAX_KEYWORDS);
+  assert.deepEqual(
+    normalizeSearchTerms(undefined, [
+      "Akyo",
+      "キャラクター",
+      "avatar",
+      "たなばた",
+    ]),
+    ["たなばた"]
+  );
   assert.deepEqual(normalizeSearchTerms("たなばたAkyo", []), ["たなばたAkyo"]);
 });
 
@@ -304,6 +315,8 @@ test("uses only specific terms for fallback search", async () => {
   );
 
   assert.equal(results[0].id, "0893");
+  assert.deepEqual(database.exactCandidates, ["たなばた"]);
+  assert.deepEqual(database.partialKeywords, ["たなばた"]);
   assert.deepEqual(ai.calls, ["たなばた"]);
 });
 

--- a/workers/akyo-search-worker/src/search.ts
+++ b/workers/akyo-search-worker/src/search.ts
@@ -13,6 +13,7 @@ export const MAX_KEYWORDS = 3;
 
 const EMBEDDING_MODEL = "@cf/baai/bge-m3";
 const MIN_SEMANTIC_SCORE = 0.35;
+const MAX_KEYWORD_CANDIDATES = 24;
 const GENERIC_SEARCH_TERMS = new Set([
   "akyo",
   "アバター",
@@ -122,7 +123,7 @@ export function normalizeSearchTerms(
     : [query ?? keywords];
   const terms: string[] = [];
 
-  for (const value of values) {
+  for (const value of values.slice(0, MAX_KEYWORD_CANDIDATES)) {
     if (typeof value !== "string") {
       continue;
     }

--- a/workers/akyo-search-worker/src/search.ts
+++ b/workers/akyo-search-worker/src/search.ts
@@ -13,6 +13,15 @@ export const MAX_KEYWORDS = 3;
 
 const EMBEDDING_MODEL = "@cf/baai/bge-m3";
 const MIN_SEMANTIC_SCORE = 0.35;
+const GENERIC_SEARCH_TERMS = new Set([
+  "akyo",
+  "アバター",
+  "キャラクター",
+  "avatar",
+  "character",
+  "아바타",
+  "캐릭터",
+]);
 
 interface SearchRow extends AkyoRecord {
   match_score: number;
@@ -137,6 +146,14 @@ export function normalizeSearchTerms(
   }
 
   return terms;
+}
+
+function prioritizeSpecificTerms(terms: string[]): string[] {
+  const specificTerms = terms.filter(
+    (term) => !GENERIC_SEARCH_TERMS.has(term.toLowerCase())
+  );
+
+  return specificTerms.length > 0 ? specificTerms : terms;
 }
 
 export function selectVectorIndex(env: Env): VectorizeIndex {
@@ -395,14 +412,13 @@ export async function searchWithD1AndVectorize(
   env: Env
 ): Promise<SearchResult[]> {
   const limit = normalizeTopK(requestedTopK);
-  const terms = normalizeSearchTerms(undefined, rawTerms);
+  const terms = prioritizeSpecificTerms(
+    normalizeSearchTerms(undefined, rawTerms)
+  );
   const exactResults = new Map<string, SearchResult>();
-  const exactTerms = terms.length > 1
-    ? terms.filter((term) => term.toLowerCase() !== "akyo")
-    : terms;
 
   const exactMatches = await Promise.all(
-    exactTerms.flatMap((term) =>
+    terms.flatMap((term) =>
       exactCandidates(term).map((candidate) =>
         findExactCandidateMatches(candidate, language, limit, env)
       )

--- a/workers/akyo-search-worker/src/search.ts
+++ b/workers/akyo-search-worker/src/search.ts
@@ -133,9 +133,6 @@ export function normalizeSearchTerms(
     if (!terms.some((item) => item.toLowerCase() === cleaned.toLowerCase())) {
       terms.push(cleaned);
     }
-    if (terms.length === MAX_KEYWORDS) {
-      break;
-    }
   }
 
   if (terms.length === 0 && Array.isArray(keywords) && typeof query === "string") {
@@ -145,7 +142,7 @@ export function normalizeSearchTerms(
     }
   }
 
-  return terms;
+  return prioritizeSpecificTerms(terms).slice(0, MAX_KEYWORDS);
 }
 
 function prioritizeSpecificTerms(terms: string[]): string[] {
@@ -412,9 +409,7 @@ export async function searchWithD1AndVectorize(
   env: Env
 ): Promise<SearchResult[]> {
   const limit = normalizeTopK(requestedTopK);
-  const terms = prioritizeSpecificTerms(
-    normalizeSearchTerms(undefined, rawTerms)
-  );
+  const terms = normalizeSearchTerms(undefined, rawTerms);
   const exactResults = new Map<string, SearchResult>();
 
   const exactMatches = await Promise.all(


### PR DESCRIPTION
## Summary
- prioritize concrete keywords when Dify supplies generic helper terms such as `Akyo` or `キャラクター`
- apply the same filtered terms to exact, partial, and Vectorize searches
- preserve existing behavior when a request contains only generic terms
- add a regression test for the production keyword set `["たなばた", "Akyo", "キャラクター"]`

## Context
PR #424 prevented a generic `Akyo` exact match from short-circuiting the search. Production verification showed that partial and semantic fallback searches still received the generic terms and filled the result limit with unrelated Akyo records. This follow-up filters generic helper terms only when at least one concrete term is available.

## Validation
- `npm run test:worker` (29 passed)
- `npm run typecheck:worker`
- `npm run build:worker`
- `npx eslint --no-ignore workers/akyo-search-worker/src/search.ts workers/akyo-search-worker/src/search.test.ts`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 検索時に一般的なキーワードを除外し、より具体的な検索語を優先して意味検索を行うよう改善しました。
  * 日本語・韓国語・英語の一般的な検索語に対応し、具体的な語がない場合は従来どおり全検索語を使用します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->