### PR TITLE
固有名検索でsemantic候補を回答しない

### DIFF
--- a/workers/akyo-search-worker/README.md
+++ b/workers/akyo-search-worker/README.md
@@ -61,6 +61,10 @@ manual production action after review.
 - Natural-language suffixes are removed before exact D1 lookup.
 - Japanese, English, and Korean queries are detected when `language` is omitted.
 - Exact ID, nickname, or avatar-name matches return without invoking Workers AI.
+- Queries that clearly name one Akyo (for example, `七夕Akyoについて教えて`
+  or `#Avatar0504`) return only the best `id`, `nickname`, or `name` match.
+  Semantic, category, author, and description candidates are excluded from
+  these responses so an unrelated avatar cannot be presented as the named one.
 - All languages, including Korean, use the populated shared index. There is no
   Korean-specific binding, and the empty JA/EN indexes remain reserved.
 - Semantic failures fall back to D1 results instead of returning an HTTP 500.
@@ -73,6 +77,9 @@ manual production action after review.
 `POST /search` accepts a JSON object with `query` or `keywords`, plus optional
 `language` (`ja`, `en`, or `ko`) and `topK`. It returns the detected language,
 matching records, and `count`.
+`searchMode` is `specific-name` for a named Akyo lookup and `discovery` for a
+general search. Specific-name responses also include `nameMatch`; when it is
+`false`, `results` is empty even if Vectorize found semantically similar items.
 
 ```json
 {

--- a/workers/akyo-search-worker/README.md
+++ b/workers/akyo-search-worker/README.md
@@ -62,9 +62,11 @@ manual production action after review.
 - Japanese, English, and Korean queries are detected when `language` is omitted.
 - Exact ID, nickname, or avatar-name matches return without invoking Workers AI.
 - Queries that clearly name one Akyo (for example, `七夕Akyoについて教えて`
-  or `#Avatar0504`) return only the best `id`, `nickname`, or `name` match.
-  Semantic, category, author, and description candidates are excluded from
-  these responses so an unrelated avatar cannot be presented as the named one.
+  or `#Avatar0504`) use D1 only and return the best `id`, `nickname`, or `name`
+  match. Semantic, category, author, and description searches are skipped so
+  an unrelated avatar cannot be presented as the named one. A request with no
+  `query` is treated the same way when `keywords` contains exactly one name;
+  multiple keyword-only requests remain discovery searches.
 - All languages, including Korean, use the populated shared index. There is no
   Korean-specific binding, and the empty JA/EN indexes remain reserved.
 - Semantic failures fall back to D1 results instead of returning an HTTP 500.

--- a/workers/akyo-search-worker/src/index.ts
+++ b/workers/akyo-search-worker/src/index.ts
@@ -9,6 +9,7 @@ import {
   normalizeLanguage,
   normalizeSearchTerms,
   normalizeTopK,
+  searchSpecificNameMatches,
   searchWithD1AndVectorize,
 } from "./search";
 import type { Env } from "./types";
@@ -54,22 +55,16 @@ async function handleSearch(request: Request, env: Env): Promise<Response> {
 
   const language = normalizeLanguage(body.language, terms.join(" "));
   const topK = normalizeTopK(body.topK);
-  const searchResults = await searchWithD1AndVectorize(
-    terms,
-    language,
-    topK,
-    env
-  );
-  const specificNameQuery = isSpecificNameQuery(body.query);
+  const specificNameInput =
+    typeof body.query === "string" && body.query.trim()
+      ? body.query
+      : Array.isArray(body.keywords) && body.keywords.length === 1
+        ? body.keywords[0]
+        : undefined;
+  const specificNameQuery = isSpecificNameQuery(specificNameInput);
   const results = specificNameQuery
-    ? searchResults
-        .filter(
-          (result) =>
-            result.matchType !== "semantic" &&
-            ["id", "nickname", "name"].includes(result.matchedField)
-        )
-        .slice(0, 1)
-    : searchResults;
+    ? await searchSpecificNameMatches(terms, language, env)
+    : await searchWithD1AndVectorize(terms, language, topK, env);
 
   return jsonResponse({
     query: typeof body.query === "string" ? body.query : undefined,

--- a/workers/akyo-search-worker/src/index.ts
+++ b/workers/akyo-search-worker/src/index.ts
@@ -63,7 +63,13 @@ async function handleSearch(request: Request, env: Env): Promise<Response> {
         : undefined;
   const specificNameQuery = isSpecificNameQuery(specificNameInput);
   const results = specificNameQuery
-    ? await searchSpecificNameMatches(terms, language, env)
+    ? await searchSpecificNameMatches(
+        typeof specificNameInput === "string"
+          ? [specificNameInput, ...terms]
+          : terms,
+        language,
+        env
+      )
     : await searchWithD1AndVectorize(terms, language, topK, env);
 
   return jsonResponse({

--- a/workers/akyo-search-worker/src/index.ts
+++ b/workers/akyo-search-worker/src/index.ts
@@ -5,6 +5,7 @@ import {
   isAuthorizedForIngest,
 } from "./ingest";
 import {
+  isSpecificNameQuery,
   normalizeLanguage,
   normalizeSearchTerms,
   normalizeTopK,
@@ -53,12 +54,29 @@ async function handleSearch(request: Request, env: Env): Promise<Response> {
 
   const language = normalizeLanguage(body.language, terms.join(" "));
   const topK = normalizeTopK(body.topK);
-  const results = await searchWithD1AndVectorize(terms, language, topK, env);
+  const searchResults = await searchWithD1AndVectorize(
+    terms,
+    language,
+    topK,
+    env
+  );
+  const specificNameQuery = isSpecificNameQuery(body.query);
+  const results = specificNameQuery
+    ? searchResults
+        .filter(
+          (result) =>
+            result.matchType !== "semantic" &&
+            ["id", "nickname", "name"].includes(result.matchedField)
+        )
+        .slice(0, 1)
+    : searchResults;
 
   return jsonResponse({
     query: typeof body.query === "string" ? body.query : undefined,
     keywords: Array.isArray(body.keywords) ? terms : undefined,
     language,
+    searchMode: specificNameQuery ? "specific-name" : "discovery",
+    nameMatch: specificNameQuery ? results.length > 0 : undefined,
     results,
     count: results.length,
   });

--- a/workers/akyo-search-worker/src/index.ts
+++ b/workers/akyo-search-worker/src/index.ts
@@ -62,14 +62,10 @@ async function handleSearch(request: Request, env: Env): Promise<Response> {
         ? body.keywords[0]
         : undefined;
   const specificNameQuery = isSpecificNameQuery(specificNameInput);
+  const specificNameTerms =
+    typeof specificNameInput === "string" ? [specificNameInput] : terms;
   const results = specificNameQuery
-    ? await searchSpecificNameMatches(
-        typeof specificNameInput === "string"
-          ? [specificNameInput, ...terms]
-          : terms,
-        language,
-        env
-      )
+    ? await searchSpecificNameMatches(specificNameTerms, language, env)
     : await searchWithD1AndVectorize(terms, language, topK, env);
 
   return jsonResponse({

--- a/workers/akyo-search-worker/src/search.test.ts
+++ b/workers/akyo-search-worker/src/search.test.ts
@@ -270,6 +270,9 @@ test("distinguishes specific Akyo names from discovery queries", () => {
   assert.equal(isSpecificNameQuery("모래여우Akyo에 대해 알려줘"), true);
   assert.equal(isSpecificNameQuery("#Avatar0504"), true);
   assert.equal(isSpecificNameQuery("かわいいAkyoを教えて"), false);
+  assert.equal(isSpecificNameQuery("cute Akyo"), false);
+  assert.equal(isSpecificNameQuery("かわいいAkyo"), false);
+  assert.equal(isSpecificNameQuery("귀여운 Akyo"), false);
   assert.equal(isSpecificNameQuery("七夕っぽいアバター"), false);
   assert.equal(isSpecificNameQuery("Akyo"), false);
   assert.equal(isSpecificNameQuery("akyo__"), false);

--- a/workers/akyo-search-worker/src/search.test.ts
+++ b/workers/akyo-search-worker/src/search.test.ts
@@ -7,6 +7,7 @@ import {
   MAX_KEYWORDS,
   escapeLikePattern,
   exactCandidates,
+  isSpecificNameQuery,
   normalizeSearchTerms,
   normalizeTopK,
   searchWithD1AndVectorize,
@@ -259,6 +260,16 @@ test("extracts exact avatar candidates from natural-language questions", () => {
   assert.deepEqual(exactCandidates("#Avatar0504"), ["0504", "#Avatar0504"]);
 });
 
+test("distinguishes specific Akyo names from discovery queries", () => {
+  assert.equal(isSpecificNameQuery("七夕Akyoについて教えて"), true);
+  assert.equal(isSpecificNameQuery("Tell me about Sand Fox Akyo"), true);
+  assert.equal(isSpecificNameQuery("모래여우Akyo에 대해 알려줘"), true);
+  assert.equal(isSpecificNameQuery("#Avatar0504"), true);
+  assert.equal(isSpecificNameQuery("かわいいAkyoを教えて"), false);
+  assert.equal(isSpecificNameQuery("七夕っぽいアバター"), false);
+  assert.equal(isSpecificNameQuery("Akyo"), false);
+});
+
 test("returns an exact D1 match without invoking Workers AI", async () => {
   const database = new FakeDatabase();
   database.exactRows = [row()];
@@ -453,6 +464,103 @@ test("search endpoint clamps topK before returning results", async () => {
   assert.equal(body.results.length, 8);
   assert.deepEqual(sharedIndex.queryTopK, [24]);
   assert.deepEqual(japaneseIndex.queryTopK, []);
+});
+
+test("does not return semantic candidates for an unknown specific Akyo name", async () => {
+  const sharedIndex = new FakeVectorize([
+    {
+      id: "0138",
+      score: 0.9,
+      metadata: {
+        id: "0138",
+        nickname: "はーふAkyo",
+        name: "akyo_half",
+        category: "体型",
+        author: "ささのき",
+        language: "ja",
+      },
+    },
+  ]);
+  const response = await worker.fetch(
+    new Request("https://worker.example/search", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        query: "ぬへもらふAkyoについて教えて",
+        keywords: ["ぬへもらふ", "Akyo"],
+      }),
+    }),
+    fakeEnv({ vectorize: sharedIndex })
+  );
+  const body = (await response.json()) as {
+    searchMode?: string;
+    nameMatch?: boolean;
+    count: number;
+    results: unknown[];
+  };
+
+  assert.equal(response.status, 200);
+  assert.equal(body.searchMode, "specific-name");
+  assert.equal(body.nameMatch, false);
+  assert.equal(body.count, 0);
+  assert.deepEqual(body.results, []);
+});
+
+test("keeps the best lexical name match for a specific Akyo query", async () => {
+  const database = new FakeDatabase();
+  database.partialRows = [
+    row({ match_score: 0.85, matched_field: "nickname" }),
+  ];
+  const sharedIndex = new FakeVectorize(vectorMatches(3));
+  const response = await worker.fetch(
+    new Request("https://worker.example/search", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        query: "七夕Akyoについて教えて",
+        keywords: ["たなばた", "Akyo"],
+      }),
+    }),
+    fakeEnv({ database, vectorize: sharedIndex })
+  );
+  const body = (await response.json()) as {
+    searchMode?: string;
+    nameMatch?: boolean;
+    count: number;
+    results: Array<{ id: string; matchType: string; matchedField: string }>;
+  };
+
+  assert.equal(response.status, 200);
+  assert.equal(body.searchMode, "specific-name");
+  assert.equal(body.nameMatch, true);
+  assert.equal(body.count, 1);
+  assert.deepEqual(body.results.map((result) => result.id), ["0893"]);
+  assert.equal(body.results[0].matchType, "partial");
+  assert.equal(body.results[0].matchedField, "nickname");
+});
+
+test("keeps semantic candidates for discovery queries", async () => {
+  const sharedIndex = new FakeVectorize(vectorMatches(3));
+  const response = await worker.fetch(
+    new Request("https://worker.example/search", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ query: "七夕っぽいアバター" }),
+    }),
+    fakeEnv({ vectorize: sharedIndex })
+  );
+  const body = (await response.json()) as {
+    searchMode?: string;
+    nameMatch?: boolean;
+    count: number;
+    results: Array<{ matchType: string }>;
+  };
+
+  assert.equal(response.status, 200);
+  assert.equal(body.searchMode, "discovery");
+  assert.equal(body.nameMatch, undefined);
+  assert.equal(body.count, 3);
+  assert.ok(body.results.every((result) => result.matchType === "semantic"));
 });
 
 test("returns 400 for malformed JSON request bodies", async () => {

--- a/workers/akyo-search-worker/src/search.test.ts
+++ b/workers/akyo-search-worker/src/search.test.ts
@@ -559,6 +559,45 @@ test("keeps the best lexical name match for a specific Akyo query", async () => 
   assert.deepEqual(sharedIndex.queryTopK, []);
 });
 
+test("searches the original specific name when generated keywords differ", async () => {
+  const database = new FakeDatabase();
+  database.exactRows = [
+    row({ match_score: 0.98, matched_field: "name" }),
+  ];
+  const ai = new FakeAi();
+  const sharedIndex = new FakeVectorize(vectorMatches(3));
+  const response = await worker.fetch(
+    new Request("https://worker.example/search", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        query: "七夕Akyoについて教えて",
+        keywords: ["星祭り"],
+      }),
+    }),
+    fakeEnv({ database, ai, vectorize: sharedIndex })
+  );
+  const body = (await response.json()) as {
+    searchMode?: string;
+    nameMatch?: boolean;
+    count: number;
+    results: Array<{ id: string; matchedField: string }>;
+  };
+
+  assert.equal(body.searchMode, "specific-name");
+  assert.equal(body.nameMatch, true);
+  assert.equal(body.count, 1);
+  assert.deepEqual(
+    body.results.map((result) => ({
+      id: result.id,
+      matchedField: result.matchedField,
+    })),
+    [{ id: "0893", matchedField: "name" }]
+  );
+  assert.deepEqual(ai.calls, []);
+  assert.deepEqual(sharedIndex.queryTopK, []);
+});
+
 test("treats one keyword-only Akyo name as a specific-name query", async () => {
   const ai = new FakeAi();
   const sharedIndex = new FakeVectorize(vectorMatches(3));

--- a/workers/akyo-search-worker/src/search.test.ts
+++ b/workers/akyo-search-worker/src/search.test.ts
@@ -601,6 +601,37 @@ test("searches the original specific name when generated keywords differ", async
   assert.deepEqual(sharedIndex.queryTopK, []);
 });
 
+test("does not replace an unknown specific name with a keyword match", async () => {
+  const database = new FakeDatabase();
+  database.exactRows = [row()];
+  const ai = new FakeAi();
+  const sharedIndex = new FakeVectorize(vectorMatches(3));
+  const response = await worker.fetch(
+    new Request("https://worker.example/search", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        query: "未登録Akyoについて教えて",
+        keywords: ["たなばたAkyo"],
+      }),
+    }),
+    fakeEnv({ database, ai, vectorize: sharedIndex })
+  );
+  const body = (await response.json()) as {
+    searchMode?: string;
+    nameMatch?: boolean;
+    count: number;
+    results: unknown[];
+  };
+
+  assert.equal(body.searchMode, "specific-name");
+  assert.equal(body.nameMatch, false);
+  assert.equal(body.count, 0);
+  assert.deepEqual(body.results, []);
+  assert.deepEqual(ai.calls, []);
+  assert.deepEqual(sharedIndex.queryTopK, []);
+});
+
 test("treats one keyword-only Akyo name as a specific-name query", async () => {
   const ai = new FakeAi();
   const sharedIndex = new FakeVectorize(vectorMatches(3));

--- a/workers/akyo-search-worker/src/search.test.ts
+++ b/workers/akyo-search-worker/src/search.test.ts
@@ -103,6 +103,10 @@ class FakeDatabase implements D1Database {
       this.partialKeywords.push(String(values[0] ?? ""));
       return this.partialRows;
     }
+    if (query.includes("WHEN nickname LIKE ?") && query.includes("ELSE 'name'")) {
+      this.partialKeywords.push(String(values[0] ?? ""));
+      return this.partialRows;
+    }
     return [];
   }
 }
@@ -268,6 +272,7 @@ test("distinguishes specific Akyo names from discovery queries", () => {
   assert.equal(isSpecificNameQuery("かわいいAkyoを教えて"), false);
   assert.equal(isSpecificNameQuery("七夕っぽいアバター"), false);
   assert.equal(isSpecificNameQuery("Akyo"), false);
+  assert.equal(isSpecificNameQuery("akyo__"), false);
 });
 
 test("returns an exact D1 match without invoking Workers AI", async () => {
@@ -467,6 +472,7 @@ test("search endpoint clamps topK before returning results", async () => {
 });
 
 test("does not return semantic candidates for an unknown specific Akyo name", async () => {
+  const ai = new FakeAi();
   const sharedIndex = new FakeVectorize([
     {
       id: "0138",
@@ -490,7 +496,7 @@ test("does not return semantic candidates for an unknown specific Akyo name", as
         keywords: ["ぬへもらふ", "Akyo"],
       }),
     }),
-    fakeEnv({ vectorize: sharedIndex })
+    fakeEnv({ ai, vectorize: sharedIndex })
   );
   const body = (await response.json()) as {
     searchMode?: string;
@@ -504,6 +510,8 @@ test("does not return semantic candidates for an unknown specific Akyo name", as
   assert.equal(body.nameMatch, false);
   assert.equal(body.count, 0);
   assert.deepEqual(body.results, []);
+  assert.deepEqual(ai.calls, []);
+  assert.deepEqual(sharedIndex.queryTopK, []);
 });
 
 test("keeps the best lexical name match for a specific Akyo query", async () => {
@@ -511,7 +519,17 @@ test("keeps the best lexical name match for a specific Akyo query", async () => 
   database.partialRows = [
     row({ match_score: 0.85, matched_field: "nickname" }),
   ];
-  const sharedIndex = new FakeVectorize(vectorMatches(3));
+  const sharedIndex = new FakeVectorize([
+    {
+      id: "9999",
+      score: 2,
+      metadata: {
+        id: "9999",
+        nickname: "意味検索候補Akyo",
+        language: "ja",
+      },
+    },
+  ]);
   const response = await worker.fetch(
     new Request("https://worker.example/search", {
       method: "POST",
@@ -519,6 +537,7 @@ test("keeps the best lexical name match for a specific Akyo query", async () => 
       body: JSON.stringify({
         query: "七夕Akyoについて教えて",
         keywords: ["たなばた", "Akyo"],
+        topK: 1,
       }),
     }),
     fakeEnv({ database, vectorize: sharedIndex })
@@ -537,6 +556,57 @@ test("keeps the best lexical name match for a specific Akyo query", async () => 
   assert.deepEqual(body.results.map((result) => result.id), ["0893"]);
   assert.equal(body.results[0].matchType, "partial");
   assert.equal(body.results[0].matchedField, "nickname");
+  assert.deepEqual(sharedIndex.queryTopK, []);
+});
+
+test("treats one keyword-only Akyo name as a specific-name query", async () => {
+  const ai = new FakeAi();
+  const sharedIndex = new FakeVectorize(vectorMatches(3));
+  const response = await worker.fetch(
+    new Request("https://worker.example/search", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ keywords: ["未登録Akyo"] }),
+    }),
+    fakeEnv({ ai, vectorize: sharedIndex })
+  );
+  const body = (await response.json()) as {
+    searchMode?: string;
+    nameMatch?: boolean;
+    count: number;
+    results: unknown[];
+  };
+
+  assert.equal(body.searchMode, "specific-name");
+  assert.equal(body.nameMatch, false);
+  assert.equal(body.count, 0);
+  assert.deepEqual(body.results, []);
+  assert.deepEqual(ai.calls, []);
+  assert.deepEqual(sharedIndex.queryTopK, []);
+});
+
+test("keeps multiple keyword-only requests in discovery mode", async () => {
+  const ai = new FakeAi();
+  const sharedIndex = new FakeVectorize(vectorMatches(3));
+  const response = await worker.fetch(
+    new Request("https://worker.example/search", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ keywords: ["七夕", "夏"] }),
+    }),
+    fakeEnv({ ai, vectorize: sharedIndex })
+  );
+  const body = (await response.json()) as {
+    searchMode?: string;
+    nameMatch?: boolean;
+    count: number;
+  };
+
+  assert.equal(body.searchMode, "discovery");
+  assert.equal(body.nameMatch, undefined);
+  assert.equal(body.count, 3);
+  assert.deepEqual(ai.calls, ["七夕", "夏"]);
+  assert.deepEqual(sharedIndex.queryTopK, [15, 15]);
 });
 
 test("keeps semantic candidates for discovery queries", async () => {

--- a/workers/akyo-search-worker/src/search.ts
+++ b/workers/akyo-search-worker/src/search.ts
@@ -90,6 +90,26 @@ function cleanNaturalLanguageQuery(value: string): string {
   return cleaned;
 }
 
+export function isSpecificNameQuery(value: unknown): boolean {
+  if (typeof value !== "string") {
+    return false;
+  }
+
+  const candidate = cleanNaturalLanguageQuery(value);
+  if (!candidate || GENERIC_SEARCH_TERMS.has(candidate.toLowerCase())) {
+    return false;
+  }
+
+  if (/^(?:#?avatar)?\s*0*\d{1,4}$/iu.test(candidate)) {
+    return true;
+  }
+
+  return (
+    /akyo$/iu.test(candidate) ||
+    /^akyo[_-][\p{L}\p{N}_-]+$/iu.test(candidate)
+  );
+}
+
 export function exactCandidates(value: string): string[] {
   const original = value.trim().replace(/[?？!！。]+$/gu, "").trim();
   const cleaned = cleanNaturalLanguageQuery(value);

--- a/workers/akyo-search-worker/src/search.ts
+++ b/workers/akyo-search-worker/src/search.ts
@@ -23,6 +23,29 @@ const GENERIC_SEARCH_TERMS = new Set([
   "아바타",
   "캐릭터",
 ]);
+const DESCRIPTIVE_AKYO_MODIFIERS = new Set([
+  "cute",
+  "cool",
+  "pretty",
+  "funny",
+  "scary",
+  "small",
+  "big",
+  "かわいい",
+  "可愛い",
+  "かっこいい",
+  "面白い",
+  "怖い",
+  "小さい",
+  "大きい",
+  "귀여운",
+  "멋진",
+  "예쁜",
+  "재미있는",
+  "무서운",
+  "작은",
+  "큰",
+]);
 
 interface SearchRow extends AkyoRecord {
   match_score: number;
@@ -90,6 +113,15 @@ function cleanNaturalLanguageQuery(value: string): string {
   return cleaned;
 }
 
+function isDescriptiveAkyoQuery(value: string): boolean {
+  const match = value.match(/^(.*?)\s*akyo$/iu);
+  if (!match) {
+    return false;
+  }
+
+  return DESCRIPTIVE_AKYO_MODIFIERS.has(match[1].trim().toLowerCase());
+}
+
 export function isSpecificNameQuery(value: unknown): boolean {
   if (typeof value !== "string") {
     return false;
@@ -104,10 +136,11 @@ export function isSpecificNameQuery(value: unknown): boolean {
     return true;
   }
 
-  return (
-    /akyo$/iu.test(candidate) ||
-    /^akyo[_-][\p{L}\p{N}][\p{L}\p{N}_-]*$/iu.test(candidate)
-  );
+  if (/akyo$/iu.test(candidate)) {
+    return !isDescriptiveAkyoQuery(candidate);
+  }
+
+  return /^akyo[_-][\p{L}\p{N}][\p{L}\p{N}_-]*$/iu.test(candidate);
 }
 
 export function exactCandidates(value: string): string[] {

--- a/workers/akyo-search-worker/src/search.ts
+++ b/workers/akyo-search-worker/src/search.ts
@@ -106,7 +106,7 @@ export function isSpecificNameQuery(value: unknown): boolean {
 
   return (
     /akyo$/iu.test(candidate) ||
-    /^akyo[_-][\p{L}\p{N}_-]+$/iu.test(candidate)
+    /^akyo[_-][\p{L}\p{N}][\p{L}\p{N}_-]*$/iu.test(candidate)
   );
 }
 
@@ -339,6 +339,36 @@ async function findPartialMatches(
   return (result.results ?? []).map((row) => toSearchResult(row, keyword));
 }
 
+async function findPartialNameMatches(
+  keyword: string,
+  language: Language,
+  limit: number,
+  env: Env
+): Promise<SearchResult[]> {
+  const like = `%${escapeLikePattern(keyword)}%`;
+  const result = await env.DB.prepare(`
+    SELECT id, nickname, name, category, description, author, url, language,
+      CASE
+        WHEN nickname LIKE ? ESCAPE '\\' THEN 0.85
+        ELSE 0.80
+      END AS match_score,
+      CASE
+        WHEN nickname LIKE ? ESCAPE '\\' THEN 'nickname'
+        ELSE 'name'
+      END AS matched_field
+    FROM akyos
+    WHERE language = ? AND (
+      nickname LIKE ? ESCAPE '\\' OR name LIKE ? ESCAPE '\\'
+    )
+    ORDER BY match_score DESC, id ASC
+    LIMIT ?
+  `)
+    .bind(like, like, language, like, like, limit)
+    .all<SearchRow>();
+
+  return (result.results ?? []).map((row) => toSearchResult(row, keyword));
+}
+
 function metadataToResult(
   matchId: string,
   score: number,
@@ -421,6 +451,45 @@ function sortAndLimit(results: Iterable<SearchResult>, limit: number): SearchRes
   return [...results]
     .sort((left, right) => right.score - left.score || left.id.localeCompare(right.id))
     .slice(0, limit);
+}
+
+export async function searchSpecificNameMatches(
+  rawTerms: string[],
+  language: Language,
+  env: Env
+): Promise<SearchResult[]> {
+  const limit = 1;
+  const terms = normalizeSearchTerms(undefined, rawTerms);
+  const exactResults = new Map<string, SearchResult>();
+
+  const exactMatches = await Promise.all(
+    terms.flatMap((term) =>
+      exactCandidates(term).map((candidate) =>
+        findExactCandidateMatches(candidate, language, limit, env)
+      )
+    )
+  );
+  for (const matches of exactMatches) {
+    for (const match of matches) {
+      mergeResult(exactResults, match);
+    }
+  }
+
+  if (exactResults.size > 0) {
+    return sortAndLimit(exactResults.values(), limit);
+  }
+
+  const partialResults = new Map<string, SearchResult>();
+  const partialMatches = await Promise.all(
+    terms.map((term) => findPartialNameMatches(term, language, limit, env))
+  );
+  for (const matches of partialMatches) {
+    for (const match of matches) {
+      mergeResult(partialResults, match);
+    }
+  }
+
+  return sortAndLimit(partialResults.values(), limit);
 }
 
 export async function searchWithD1AndVectorize(


### PR DESCRIPTION
固有名形式の問い合わせを specific-name モードとして判定し、id・nickname・name のlexical一致だけを1件返します。未登録名では semantic・カテゴリ・作者・備考候補を除外して nameMatch: false と空結果を返し、一般的な探索クエリでは従来どおりsemantic検索を維持します。日英韓の判定と回帰テストを追加済みです。検証: npm run test:worker（34件成功）、npm run typecheck:worker、npm run build:worker、git diff --check。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Akyo検索で、特定のID・ニックネーム・名前を指定した場合に、最も一致する1件のみを表示するようになりました。
  * 単一キーワードの名前検索にも対応しました。複数キーワードによる探索検索は従来どおり利用できます。
  * 該当する名前が見つからない場合、意味検索による候補を表示せず、空の結果を返します。
  * 検索結果に検索モードと名前一致状況が表示されるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->